### PR TITLE
explicit Taps for MapReduceFlow

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,9 @@
 Cascading Change Log
 
+1.2.3 [unreleased]
+
+  Fixed bug in c.t.GlobHfs where #equals() and #hashCode() were not consistent between calls.
+
 1.2.2
 
   Fixed bug where OOME caught from within the source c.t.Tap was not being re-thrown properly.

--- a/src/core/cascading/flow/MapReduceFlow.java
+++ b/src/core/cascading/flow/MapReduceFlow.java
@@ -125,6 +125,67 @@ public class MapReduceFlow extends Flow
     setStepGraph( makeStepGraph( jobConf ) );
     }
 
+  /**
+   * Constructor MapReduceFlow creates a new MapReduceFlow instance.
+   *
+   * @param name             of type String
+   * @param jobConf          of type JobConf
+   * @param source           of type Tap
+   * @param sink             of type Tap
+   * @param deleteSinkOnInit of type boolean
+   * @param stopJobsOnExit   of type boolean
+   */
+  @ConstructorProperties({"name", "jobConf", "source", "sink", "deleteSinkOnInit", "stopJobsOnExit"})
+  public MapReduceFlow( String name, JobConf jobConf, Tap source, Tap sink, boolean deleteSinkOnInit, boolean stopJobsOnExit )
+    {
+      this( name, jobConf, null, null, null, deleteSinkOnInit, stopJobsOnExit );
+
+      Map<String, Tap> sources = new HashMap<String, Tap>();
+      Map<String, Tap> sinks   = new HashMap<String, Tap>();
+      Map<String, Tap> traps   = new HashMap<String, Tap>();
+
+      sources.put( source.getPath().toString(), source );
+      sinks.put( sink.getPath().toString(), sink );
+
+      setSources( sources );
+      setSinks( sinks );
+      setTraps( traps );
+      setStepGraph( makeStepGraph( jobConf ) );
+    }
+
+  /**
+   * Constructor MapReduceFlow creates a new MapReduceFlow instance.
+   *
+   * @param name             of type String
+   * @param jobConf          of type JobConf
+   * @param sources          of type Map<String, Tap>
+   * @param sinks            of type Map<String, Tap>
+   * @param traps            of type Map<String, Tap>
+   * @param deleteSinkOnInit of type boolean
+   * @param stopJobsOnExit   of type boolean
+   */
+  @ConstructorProperties({"name", "jobConf", "sources", "sinks", "traps", "deleteSinkOnInit", "stopJobsOnExit"})
+  public MapReduceFlow( String name, JobConf jobConf, Map<String, Tap> sources, Map<String, Tap> sinks, Map<String, Tap> traps, 
+      boolean deleteSinkOnInit, boolean stopJobsOnExit )
+    {
+    this.deleteSinkOnInit = deleteSinkOnInit;
+    this.stopJobsOnExit = stopJobsOnExit;
+
+    setName( name );
+
+    if( sources != null )
+      setSources( sources );
+
+    if( sinks != null )
+      setSinks( sinks );
+
+    if( traps != null )
+      setTraps( traps );
+
+    if( (sources != null) && (sinks != null) && (traps != null) )
+      setStepGraph( makeStepGraph( jobConf ) );
+    }
+
   private StepGraph makeStepGraph( JobConf jobConf )
     {
     StepGraph stepGraph = new StepGraph();

--- a/src/core/cascading/tap/MultiSourceTap.java
+++ b/src/core/cascading/tap/MultiSourceTap.java
@@ -183,7 +183,7 @@ public class MultiSourceTap extends SourceTap implements CompositeTap
   @Override
   public TupleEntryIterator openForRead( JobConf conf ) throws IOException
     {
-    Iterator iterators[] = new Iterator[getTaps().length];
+    Iterator iterators[] = new Iterator[ getTaps().length ];
 
     for( int i = 0; i < getTaps().length; i++ )
       iterators[ i ] = new TupleIterator( getTaps()[ i ].openForRead( conf ) );
@@ -202,7 +202,7 @@ public class MultiSourceTap extends SourceTap implements CompositeTap
 
     MultiSourceTap multiTap = (MultiSourceTap) object;
 
-    if( !Arrays.equals( taps, multiTap.taps ) )
+    if( !Arrays.equals( getTaps(), multiTap.getTaps() ) )
       return false;
 
     return true;
@@ -211,12 +211,12 @@ public class MultiSourceTap extends SourceTap implements CompositeTap
   public int hashCode()
     {
     int result = super.hashCode();
-    result = 31 * result + ( taps != null ? Arrays.hashCode( taps ) : 0 );
+    result = 31 * result + ( getTaps() != null ? Arrays.hashCode( getTaps() ) : 0 );
     return result;
     }
 
   public String toString()
     {
-    return "MultiSourceTap[" + ( taps == null ? "none" : Arrays.asList( taps ) ) + ']';
+    return "MultiSourceTap[" + ( getTaps() == null ? "none" : Arrays.asList( Arrays.copyOf( getTaps(), 10 ) ) ) + ']';
     }
   }

--- a/src/test/cascading/tap/TapTest.java
+++ b/src/test/cascading/tap/TapTest.java
@@ -373,7 +373,12 @@ public class TapTest extends ClusterTestCase implements Serializable
     copyFromLocal( inputFileLower );
     copyFromLocal( inputFileUpper );
 
-    Tap source = new GlobHfs( new TextLine( new Fields( "offset", "line" ) ), "build/test/data/?{ppe[_r],owe?}.txt" );
+    GlobHfs source = new GlobHfs( new TextLine( new Fields( "offset", "line" ) ), "build/test/data/?{ppe[_r],owe?}.txt" );
+
+    assertEquals( 2, source.getTaps().length );
+
+    // show globhfs will just match a directory if ended with a /
+    assertEquals( 1, new GlobHfs( new TextLine( new Fields( "offset", "line" ) ), "build/test/?ata/" ).getTaps().length );
 
     // using null pos so all fields are written
     Tap sink = new Hfs( new TextLine(), outputPath + "/glob/", true );


### PR DESCRIPTION
Hello Chris,

I and my colleagues at WeatherBill love using Cascading. Recently I started using Cascading with Hadoop Streaming. While troubleshooting, I found this post by Nate Murray in the Cascading user group

http://groups.google.com/group/cascading-user/browse_thread/thread/b9d9b1ea87cc1564/34c30f8

and Nate encouraged me to try his patch against the latest Cascading. This change is essential for users who want to use Cascading to organize multiple Hadoop Streaming flows. Please critique and demand any additional changes, tests,  etc. that you need for this change to be accepted.

Thank you.

Steve Kim
