### PR TITLE
Add sources JAR to build artifacts

### DIFF
--- a/src/build.gradle
+++ b/src/build.gradle
@@ -30,12 +30,18 @@ subprojects { subproject ->
   apply plugin: 'java'
   apply plugin: 'maven'
 
+  task sourcesJar(type: Jar, dependsOn:classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+  }
+ 
   configure(subproject.jar) {
     manifest.attributes version: project.version
   }
 
   configure(subproject.artifacts) {
     archives jar
+    archives sourcesJar
   }
 
   configure(install.repositories.mavenInstaller) {


### PR DESCRIPTION
This adds the sources (JAR) to the build artifacts. It's very handy during development (Maven Eclipse plugin will download them automatically).
