### PR TITLE
Abstract out Flow Serialization implementation behind FlowSerialization interface

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,6 +17,10 @@ Cascading Change Log
 
   Fixed issue where c.p.CoGroup was not properly resolving fields from immediate prior c.p.Every pipes.
 
+  Flow Serialization is now customizable. To override the default c.f.h.util.JavaFlowSerializer, specify the name of
+  a class that implements c.f.h.u.FlowSerializer (and optionally extends org.apache.hadoop.conf.Configured) via the
+  "cascading.flow.serializer" JobConf property.
+
 2.0.1
 
   Changed c.s.h.TextDelimited to use fully qualified path when reading headers so that the filesystem scheme

--- a/src/hadoop/cascading/flow/hadoop/FlowMapper.java
+++ b/src/hadoop/cascading/flow/hadoop/FlowMapper.java
@@ -74,7 +74,7 @@ public class FlowMapper implements MapRunnable
       if( stepState == null )
         stepState = readStateFromDistCache( jobConf, jobConf.get( FlowStep.CASCADING_FLOW_STEP_ID ) );
 
-      HadoopFlowStep step = (HadoopFlowStep) deserializeBase64( stepState );
+      HadoopFlowStep step = deserializeBase64( stepState, jobConf, HadoopFlowStep.class );
       Tap source = step.getTapForID( step.getSources(), jobConf.get( "cascading.step.source" ) );
 
       streamGraph = new HadoopMapStreamGraph( currentProcess, step, source );

--- a/src/hadoop/cascading/flow/hadoop/FlowReducer.java
+++ b/src/hadoop/cascading/flow/hadoop/FlowReducer.java
@@ -82,7 +82,7 @@ public class FlowReducer extends MapReduceBase implements Reducer
       if( stepState == null )
         stepState = readStateFromDistCache( jobConf, jobConf.get( FlowStep.CASCADING_FLOW_STEP_ID ) );
 
-      HadoopFlowStep step = (HadoopFlowStep) deserializeBase64( stepState );
+      HadoopFlowStep step = deserializeBase64( stepState, jobConf, HadoopFlowStep.class );
 
       streamGraph = new HadoopReduceStreamGraph( currentProcess, step );
 

--- a/src/hadoop/cascading/flow/hadoop/HadoopFlowStep.java
+++ b/src/hadoop/cascading/flow/hadoop/HadoopFlowStep.java
@@ -59,7 +59,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.FileOutputFormat;
 import org.apache.hadoop.mapred.JobConf;
 
-import static cascading.flow.hadoop.util.HadoopUtil.*;
+import static cascading.flow.hadoop.util.HadoopUtil.serializeBase64;
+import static cascading.flow.hadoop.util.HadoopUtil.writeStateToDistCache;
 
 /**
  *
@@ -165,7 +166,7 @@ public class HadoopFlowStep extends BaseFlowStep<JobConf>
     conf.set( CASCADING_FLOW_STEP_ID, getID() );
     conf.set( "cascading.flow.step.num", Integer.toString( getStepNum() ) );
 
-    String stepState = pack( this );
+    String stepState = pack( this, conf );
 
     // hadoop 20.2 doesn't like dist cache when using local mode
     int maxSize = Short.MAX_VALUE;
@@ -182,14 +183,11 @@ public class HadoopFlowStep extends BaseFlowStep<JobConf>
     return "local".equals( conf.get( "mapred.job.tracker" ) );
     }
 
-  private String pack( Object object )
+  private String pack( Object object, JobConf conf )
     {
     try
       {
-      if( object instanceof Map )
-        return serializeMapBase64( (Map<String, String>) object, true );
-
-      return serializeBase64( object );
+      return serializeBase64( object, conf, true);
       }
     catch( IOException exception )
       {
@@ -288,7 +286,7 @@ public class HadoopFlowStep extends BaseFlowStep<JobConf>
 
     if( fields.hasComparators() )
       {
-      conf.set( property, pack( fields ) );
+      conf.set( property, pack( fields, conf ) );
       return;
       }
 
@@ -341,7 +339,7 @@ public class HadoopFlowStep extends BaseFlowStep<JobConf>
       JobConf accumulatedJob = flowProcess.copyConfig( conf );
       tap.sourceConfInit( flowProcess, accumulatedJob );
       Map<String, String> map = flowProcess.diffConfigIntoMap( conf, accumulatedJob );
-      conf.set( "cascading.step.accumulated.source.conf." + Tap.id( tap ), pack( map ) );
+      conf.set( "cascading.step.accumulated.source.conf." + Tap.id( tap ), pack( map, conf ) );
       }
 
     MultiInputFormat.addInputFormat( conf, streamedJobs ); //must come last

--- a/src/hadoop/cascading/flow/hadoop/stream/HadoopMapStreamGraph.java
+++ b/src/hadoop/cascading/flow/hadoop/stream/HadoopMapStreamGraph.java
@@ -100,10 +100,10 @@ public class HadoopMapStreamGraph extends StepStreamGraph
 
   private JobConf getSourceConf( HadoopFlowProcess flowProcess, JobConf conf, String property )
     {
-    Map<String, String> priorConf = null;
+    Map<String, String> priorConf;
     try
       {
-      priorConf = HadoopUtil.deserializeMapBase64( property, true );
+      priorConf = (Map<String,String>) HadoopUtil.deserializeBase64(property, conf, Map.class, true );
       }
     catch( IOException exception )
       {

--- a/src/hadoop/cascading/flow/hadoop/util/FlowSerializer.java
+++ b/src/hadoop/cascading/flow/hadoop/util/FlowSerializer.java
@@ -1,0 +1,11 @@
+package cascading.flow.hadoop.util;
+
+import java.io.IOException;
+
+/** User: sritchie Date: 7/9/12 Time: 10:43 AM */
+public interface FlowSerializer
+  {
+  public <T> byte[] serialize( T object, boolean compress) throws IOException;
+  public <T> T deserialize( byte[] bytes, Class<T> klass, boolean decompress) throws IOException;
+  public <T> boolean accepts(Class<T> klass);
+  }

--- a/src/hadoop/cascading/flow/hadoop/util/HadoopUtil.java
+++ b/src/hadoop/cascading/flow/hadoop/util/HadoopUtil.java
@@ -20,23 +20,16 @@
 
 package cascading.flow.hadoop.util;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.ObjectStreamClass;
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
 
 import cascading.flow.FlowException;
 import cascading.flow.hadoop.HadoopFlowProcess;
@@ -50,6 +43,7 @@ import cascading.tuple.TupleEntryCollector;
 import cascading.tuple.TupleEntryIterator;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.filecache.DistributedCache;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -64,6 +58,9 @@ import org.slf4j.LoggerFactory;
 public class HadoopUtil
   {
   private static final org.slf4j.Logger LOG = LoggerFactory.getLogger( HadoopUtil.class );
+  public static final String ENCODING = "US-ASCII";
+  public static final String SERIALIZATION_FACTORY_KEY = "cascading.flow.serializer";
+  public static final Class<?> DEFAULT_FLOW_SERIALIZER = JavaFlowSerializer.class;
 
   public static void initLog4j( JobConf jobConf )
     {
@@ -162,171 +159,90 @@ public class HadoopUtil
     return null;
     }
 
-  public static String serializeMapBase64( Map<String, String> map, boolean compress ) throws IOException
-    {
-    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-    ObjectOutputStream out = new ObjectOutputStream( compress ? new GZIPOutputStream( bytes ) : bytes );
-
-    try
-      {
-      out.writeInt( map.size() );
-
-      for( Map.Entry<String, String> entry : map.entrySet() )
-        writeKeyValue( out, entry.getKey(), entry.getValue() );
-      }
-    finally
-      {
-      out.close();
-      }
-
-    return new String( Base64.encodeBase64( bytes.toByteArray() ) );
-    }
-
-  public static Map<String, String> deserializeMapBase64( String string, boolean decompress ) throws IOException
-    {
-    if( string == null || string.length() == 0 )
-      return null;
-
-    ObjectInputStream in = null;
-
-    try
-      {
-      ByteArrayInputStream bytes = new ByteArrayInputStream( Base64.decodeBase64( string.getBytes() ) );
-
-      in = new ObjectInputStream( decompress ? new GZIPInputStream( bytes ) : bytes );
-
-      int mapSize = in.readInt();
-      Map<String, String> map = new HashMap<String, String>( mapSize );
-
-      for( int j = 0; j < mapSize; j++ )
-        map.put( in.readUTF(), readStringAsObject( in ) );
-
-      return map;
-      }
-    finally
-      {
-      if( in != null )
-        in.close();
-      }
-    }
-
-  public static String serializeListMapBase64( List<Map<String, String>> listMap, boolean compress ) throws IOException
-    {
-    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-
-    ObjectOutputStream out = new ObjectOutputStream( compress ? new GZIPOutputStream( bytes ) : bytes );
-
-    try
-      {
-      out.writeInt( listMap.size() );
-
-      for( Map<String, String> map : listMap )
-        {
-        out.writeInt( map.size() );
-
-        for( Map.Entry<String, String> entry : map.entrySet() )
-          writeKeyValue( out, entry.getKey(), entry.getValue() );
-        }
-      }
-    finally
-      {
-      out.close();
-      }
-
-    return new String( Base64.encodeBase64( bytes.toByteArray() ) );
-    }
-
-  private static void writeKeyValue( ObjectOutputStream out, String key, String value ) throws IOException
+  public static String encodeBytes(byte[] bytes)
     {
     try
       {
-      out.writeUTF( key );
-      // we must writeObject as it knows how to handle large Strings larger than Short max value
-      out.writeObject( value );
+      return new String(Base64.encodeBase64(bytes), ENCODING);
       }
-    catch( IOException exception )
+    catch (UnsupportedEncodingException e)
       {
-      LOG.error( "could not write key/value: " + key + "/" + value, exception );
-      throw exception;
+      throw new RuntimeException(e);
       }
     }
 
-  public static List<Map<String, String>> deserializeListMapBase64( String string, boolean decompress ) throws IOException
-    {
-    if( string == null || string.length() == 0 )
-      return null;
-
-    ObjectInputStream in = null;
-
-    try
-      {
-      ByteArrayInputStream bytes = new ByteArrayInputStream( Base64.decodeBase64( string.getBytes() ) );
-
-      in = new ObjectInputStream( decompress ? new GZIPInputStream( bytes ) : bytes );
-
-      int listSize = in.readInt();
-      List<Map<String, String>> list = new ArrayList<Map<String, String>>( listSize );
-
-      for( int i = 0; i < listSize; i++ )
-        {
-        int mapSize = in.readInt();
-
-        Map<String, String> map = new HashMap<String, String>( mapSize );
-
-        for( int j = 0; j < mapSize; j++ )
-          map.put( in.readUTF(), readStringAsObject( in ) );
-
-        list.add( map );
-        }
-
-      return list;
-      }
-    finally
-      {
-      if( in != null )
-        in.close();
-      }
-    }
-
-  private static String readStringAsObject( ObjectInputStream in ) throws IOException
+  public static byte[] decodeBytes(String str)
     {
     try
       {
-      return (String) in.readObject();
+      byte[] bytes = str.getBytes(ENCODING);
+      return Base64.decodeBase64(bytes);
       }
-    catch( ClassNotFoundException exception )
+    catch (UnsupportedEncodingException e)
       {
-      throw new FlowException( "could not read string", exception );
+      throw new RuntimeException(e);
       }
     }
 
-  /**
-   * This method serializes the given Object instance and retunrs a String Base64 representation.
-   *
-   * @param object to be serialized
-   * @return String
-   */
-  public static String serializeBase64( Object object ) throws IOException
+  public static <T> FlowSerializer instantiateSerializer(Configuration conf, Class<T> klass)
+    throws ClassNotFoundException
     {
-    return serializeBase64( object, true );
-    }
+    Class<FlowSerializer> flowSerializerClass;
 
-  public static String serializeBase64( Object object, boolean compress ) throws IOException
-    {
-    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    String serializerClassName = conf.get(SERIALIZATION_FACTORY_KEY);
 
-    ObjectOutputStream out = new ObjectOutputStream( compress ? new GZIPOutputStream( bytes ) : bytes );
+    if (serializerClassName == null || serializerClassName.length() == 0)
+      {
+      flowSerializerClass = (Class<FlowSerializer>) DEFAULT_FLOW_SERIALIZER;
+      }
+    else
+      {
+      flowSerializerClass = (Class<FlowSerializer>) Class.forName(serializerClassName);
+      }
+
+    FlowSerializer flowSerializer;
 
     try
       {
-      out.writeObject( object );
-      }
-    finally
-      {
-      out.close();
+      flowSerializer = flowSerializerClass.newInstance();
+
+      if (Configured.class.isAssignableFrom(flowSerializerClass))
+        ((Configured) flowSerializer).setConf(conf);
       }
 
-    return new String( Base64.encodeBase64( bytes.toByteArray() ) );
+    catch (Exception e)
+      {
+      e.printStackTrace();
+      throw new IllegalArgumentException("Unable to instantiate serializer \""
+        + flowSerializerClass.getName()
+        + "\" for class: "
+        + klass.getName());
+      }
+
+    if (!flowSerializer.accepts(klass))
+      throw new IllegalArgumentException(serializerClassName + " won't accept objects of class " + klass.toString());
+
+    return flowSerializer;
+    }
+
+  public static <T> String serializeBase64( T object, JobConf conf ) throws IOException
+    {
+    return serializeBase64( object, conf, true );
+    }
+
+  public static <T> String serializeBase64( T object, JobConf conf, boolean compress ) throws IOException
+    {
+    FlowSerializer flowSerializer;
+    try
+      {
+      flowSerializer = instantiateSerializer(conf, object.getClass());
+      }
+    catch (ClassNotFoundException e)
+      {
+      throw new IOException(e);
+      }
+
+    return encodeBytes(flowSerializer.serialize(object, compress));
     }
 
   /**
@@ -335,49 +251,28 @@ public class HadoopUtil
    * @param string
    * @return an Object
    */
-  public static Object deserializeBase64( String string ) throws IOException
+  public static <T> T deserializeBase64( String string, Configuration conf, Class<T> klass) throws IOException
     {
-    return deserializeBase64( string, true );
+    return deserializeBase64( string, conf, klass, true );
     }
 
-  public static Object deserializeBase64( String string, boolean decompress ) throws IOException
+  public static  <T> T deserializeBase64( String string, Configuration conf, Class<T> klass, boolean decompress ) throws IOException
     {
     if( string == null || string.length() == 0 )
       return null;
 
-    ObjectInputStream in = null;
+    FlowSerializer flowSerializer;
 
     try
       {
-      ByteArrayInputStream bytes = new ByteArrayInputStream( Base64.decodeBase64( string.getBytes() ) );
+      flowSerializer = instantiateSerializer(conf, klass);
+      }
+    catch (ClassNotFoundException e)
+      {
+      throw new IOException(e);
+      }
 
-      in = new ObjectInputStream( decompress ? new GZIPInputStream( bytes ) : bytes )
-      {
-      @Override
-      protected Class<?> resolveClass( ObjectStreamClass desc ) throws IOException, ClassNotFoundException
-        {
-        try
-          {
-          return Class.forName( desc.getName(), false, Thread.currentThread().getContextClassLoader() );
-          }
-        catch( ClassNotFoundException exception )
-          {
-          return super.resolveClass( desc );
-          }
-        }
-      };
-
-      return in.readObject();
-      }
-    catch( ClassNotFoundException exception )
-      {
-      throw new FlowException( "unable to deserialize data", exception );
-      }
-    finally
-      {
-      if( in != null )
-        in.close();
-      }
+    return flowSerializer.deserialize(decodeBytes(string), klass, decompress);
     }
 
   public static Class findMainClass( Class defaultType )

--- a/src/hadoop/cascading/flow/hadoop/util/JavaFlowSerializer.java
+++ b/src/hadoop/cascading/flow/hadoop/util/JavaFlowSerializer.java
@@ -1,0 +1,229 @@
+package cascading.flow.hadoop.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+import cascading.flow.FlowException;
+
+public class JavaFlowSerializer implements FlowSerializer
+  {
+
+  @Override public <T> byte[] serialize(T object, boolean compress) throws IOException
+    {
+
+    if( object instanceof Map)
+      return serializeMap((Map<String, ?>) object, compress);
+
+    if (object instanceof List)
+      return serializeList((List<?>) object, compress);
+
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+
+    ObjectOutputStream out = new ObjectOutputStream( compress ? new GZIPOutputStream( bytes ) : bytes );
+
+    try
+      {
+      out.writeObject( object );
+      }
+    finally
+      {
+      out.close();
+      }
+
+    return bytes.toByteArray();
+    }
+
+  @Override public <T> T deserialize(byte[] bytes, Class<T> klass, boolean decompress)
+    throws IOException
+    {
+
+    if (Map.class.isAssignableFrom(klass))
+      return (T) deserializeMap(bytes, decompress);
+
+    if(List.class.isAssignableFrom(klass)) {
+    return (T) deserializeList(bytes, decompress);
+    }
+
+    ObjectInputStream in = null;
+
+    try
+      {
+      ByteArrayInputStream byteStream = new ByteArrayInputStream( bytes );
+
+      in = new ObjectInputStream( decompress ? new GZIPInputStream( byteStream ) : byteStream )
+      {
+      @Override
+      protected Class<?> resolveClass( ObjectStreamClass desc ) throws IOException, ClassNotFoundException
+        {
+        try
+          {
+          return Class.forName( desc.getName(), false, Thread.currentThread().getContextClassLoader() );
+          }
+        catch( ClassNotFoundException exception )
+          {
+          return super.resolveClass( desc );
+          }
+        }
+      };
+
+      return (T) in.readObject();
+      }
+    catch( ClassNotFoundException exception )
+      {
+      throw new FlowException( "unable to deserialize data", exception );
+      }
+    finally
+      {
+      if( in != null )
+        in.close();
+      }
+    }
+
+  @Override public <T> boolean accepts(Class<T> klass)
+    {
+    return Serializable.class.isAssignableFrom(klass)
+      || Map.class.isAssignableFrom(klass)
+      || List.class.isAssignableFrom(klass);
+    }
+
+  public <T> byte[] serializeMap( Map<String, T> map, boolean compress ) throws IOException
+    {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    ObjectOutputStream out = new ObjectOutputStream( compress ? new GZIPOutputStream( bytes ) : bytes );
+
+    Class<T> tClass;
+
+    if(map.size() == 0)
+      tClass = (Class<T>) Object.class;
+    else
+      tClass = (Class<T>) map.values().iterator().next().getClass();
+    try
+      {
+      out.writeInt( map.size() );
+      out.writeUTF(tClass.getName());
+
+      for( Map.Entry<String, T> entry : map.entrySet() ) {
+      out.writeUTF(entry.getKey());
+      byte[] itemBytes = serialize(entry.getValue(), false);
+      out.writeInt(itemBytes.length);
+      out.write(itemBytes);
+      }
+      }
+    finally
+      {
+      out.close();
+      }
+
+    return bytes.toByteArray();
+    }
+
+  public <T> Map<String, T> deserializeMap( byte[] bytes, boolean decompress )
+    throws IOException
+    {
+    ObjectInputStream in = null;
+
+    try
+      {
+      ByteArrayInputStream byteStream = new ByteArrayInputStream( bytes );
+
+      in = new ObjectInputStream( decompress ? new GZIPInputStream( byteStream ) : byteStream );
+
+      int mapSize = in.readInt();
+      Class<T> tClass = (Class<T>) Class.forName(in.readUTF());
+
+      Map<String, T> map = new HashMap<String, T>( mapSize );
+
+      for( int j = 0; j < mapSize; j++ ) {
+      String key = in.readUTF();
+      byte[] valBytes = new byte[in.readInt()];
+      in.readFully(valBytes);
+      map.put( key, deserialize(valBytes, tClass, false) );
+      }
+
+      return map;
+      } catch (ClassNotFoundException e) {
+    throw new IOException(e);
+    } finally
+      {
+      if( in != null )
+        in.close();
+      }
+    }
+
+  public <T> byte[] serializeList(List<T> list, boolean compress) throws IOException
+    {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+
+    ObjectOutputStream out = new ObjectOutputStream( compress ? new GZIPOutputStream( bytes ) : bytes );
+
+    Class<T> tClass;
+
+    if(list.size() == 0)
+      tClass = (Class<T>) Object.class;
+    else
+      tClass = (Class<T>) list.get(0).getClass();
+
+    try
+      {
+      out.writeInt( list.size() );
+      out.writeUTF(tClass.getName());
+
+      for( T item : list )
+        {
+        byte[] itemBytes = serialize(item, false);
+        out.writeInt( itemBytes.length );
+        out.write(itemBytes);
+        }
+      }
+    finally
+      {
+      out.close();
+      }
+
+    return bytes.toByteArray();
+    }
+
+  public <T> List<T> deserializeList(byte[] bytes, boolean decompress)
+    throws IOException
+    {
+    ObjectInputStream in = null;
+
+    try
+      {
+      ByteArrayInputStream byteStream = new ByteArrayInputStream( bytes );
+
+      in = new ObjectInputStream( decompress ? new GZIPInputStream( byteStream ) : byteStream );
+
+      int listSize = in.readInt();
+      Class<T> tClass = (Class<T>) Class.forName(in.readUTF());
+
+      List<T> list = new ArrayList<T>( listSize );
+
+      for( int i = 0; i < listSize; i++ )
+        {
+        byte[] itemBytes = new byte[in.readInt()];
+        in.readFully(itemBytes);
+        list.add(deserialize(itemBytes, tClass, false));
+        }
+
+      return list;
+      } catch (ClassNotFoundException e) {
+    throw new IOException(e);
+    } finally
+      {
+      if( in != null )
+        in.close();
+      }
+    }
+  }

--- a/src/hadoop/cascading/tap/hadoop/io/MultiInputFormat.java
+++ b/src/hadoop/cascading/tap/hadoop/io/MultiInputFormat.java
@@ -20,26 +20,17 @@
 
 package cascading.tap.hadoop.io;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
 import cascading.CascadingException;
 import cascading.flow.hadoop.util.HadoopUtil;
 import cascading.util.Util;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.mapred.FileInputFormat;
-import org.apache.hadoop.mapred.InputFormat;
-import org.apache.hadoop.mapred.InputSplit;
-import org.apache.hadoop.mapred.JobConf;
-import org.apache.hadoop.mapred.RecordReader;
-import org.apache.hadoop.mapred.Reporter;
+import org.apache.hadoop.mapred.*;
 import org.jets3t.service.S3ServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.*;
 
 /**
  * Class MultiInputFormat accepts multiple InputFormat class declarations allowing a single MR job
@@ -77,7 +68,7 @@ public class MultiInputFormat implements InputFormat
 
     try
       {
-      toJob.set( "cascading.multiinputformats", HadoopUtil.serializeListMapBase64( configs, true ) );
+      toJob.set( "cascading.multiinputformats", HadoopUtil.serializeBase64( configs, toJob, true ) );
       }
     catch( IOException exception )
       {
@@ -100,7 +91,8 @@ public class MultiInputFormat implements InputFormat
 
   private List<Map<String, String>> getConfigs( JobConf job ) throws IOException
     {
-    return (List<Map<String, String>>) HadoopUtil.deserializeListMapBase64( job.get( "cascading.multiinputformats" ), true );
+    return (List<Map<String, String>>)
+        HadoopUtil.deserializeBase64( job.get( "cascading.multiinputformats" ), job, List.class, true );
     }
 
   public void validateInput( JobConf job ) throws IOException

--- a/src/hadoop/cascading/tuple/hadoop/util/DeserializerComparator.java
+++ b/src/hadoop/cascading/tuple/hadoop/util/DeserializerComparator.java
@@ -20,9 +20,6 @@
 
 package cascading.tuple.hadoop.util;
 
-import java.io.IOException;
-import java.util.Comparator;
-
 import cascading.CascadingException;
 import cascading.flow.hadoop.util.HadoopUtil;
 import cascading.tuple.Fields;
@@ -34,6 +31,9 @@ import cascading.tuple.hadoop.io.HadoopTupleInputStream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.io.RawComparator;
+
+import java.io.IOException;
+import java.util.Comparator;
 
 /** Class DeserializerComparator is the base class for all Cascading comparator classes. */
 public abstract class DeserializerComparator<T> extends Configured implements RawComparator<T>
@@ -85,7 +85,7 @@ public abstract class DeserializerComparator<T> extends Configured implements Ra
 
     try
       {
-      return ( (Fields) HadoopUtil.deserializeBase64( value ) ).getComparators();
+      return HadoopUtil.deserializeBase64( value, conf, Fields.class ).getComparators();
       }
     catch( IOException exception )
       {


### PR DESCRIPTION
This pull request abstracts the current FlowStep serialization strategy into `JavaFlowSerializer`, which implements `FlowSerializer`. This will allow the FlowStep serialization mechanism to be pluggable via the `"cascading.flow.serializer"` JobConf property.
