### PR TITLE
Supply actual classes vs interfaces.

### DIFF
--- a/src/hadoop/cascading/flow/hadoop/stream/HadoopMapStreamGraph.java
+++ b/src/hadoop/cascading/flow/hadoop/stream/HadoopMapStreamGraph.java
@@ -103,7 +103,7 @@ public class HadoopMapStreamGraph extends StepStreamGraph
     Map<String, String> priorConf;
     try
       {
-      priorConf = (Map<String, String>) HadoopUtil.deserializeBase64( property, conf, Map.class, true );
+      priorConf = (Map<String, String>) HadoopUtil.deserializeBase64( property, conf, HashMap.class, true );
       }
     catch( IOException exception )
       {

--- a/src/hadoop/cascading/tap/hadoop/io/MultiInputFormat.java
+++ b/src/hadoop/cascading/tap/hadoop/io/MultiInputFormat.java
@@ -101,7 +101,7 @@ public class MultiInputFormat implements InputFormat
   private List<Map<String, String>> getConfigs( JobConf job ) throws IOException
     {
     return (List<Map<String, String>>)
-      HadoopUtil.deserializeBase64( job.get( "cascading.multiinputformats" ), job, List.class, true );
+      HadoopUtil.deserializeBase64( job.get( "cascading.multiinputformats" ), job, ArrayList.class, true );
     }
 
   public void validateInput( JobConf job ) throws IOException


### PR DESCRIPTION
Deserializations that use these classes (like Kryo) need concrete classes, not interfaces.
