### PR TITLE
Updating Tap's outgoingScopeFor so that it gracefully handles null or empty HashSets

### DIFF
--- a/src/core/cascading/tap/Tap.java
+++ b/src/core/cascading/tap/Tap.java
@@ -318,7 +318,10 @@ public abstract class Tap<Config, Input, Output> implements FlowElement, Seriali
       throw new FlowException( "Tap may not have more than one incoming Scope" );
 
     // this allows the incoming to be passed through to the outgoing
-    Fields incomingFields = resolveFields( incomingScopes.iterator().next() );
+    Fields incomingFields = null;
+    if (incomingScopes != null && 
+        !incomingScopes.isEmpty())
+      incomingFields = resolveFields( incomingScopes.iterator().next() );
 
     if( incomingFields != null &&
       ( isSource() && getSourceFields().equals( Fields.UNKNOWN ) ||


### PR DESCRIPTION
I ran into this issue when upgrading cascading.jruby from Cascading 2.0.0-wip-255 to 2.0.3.  A number of tests in the cascading.jruby suite started failing, throwing a somewhat obscure exception on HashMap from the underlying Cascading library.

The issue turns out to have been introduced in this [commit](https://github.com/cwensel/cascading/commit/5ea3837fc0676bcc035acc0f76e93e987c00cc15#src/core/cascading/tap/Tap.java).  The logic allowing the passthrough of incoming to outgoing now throws a somewhat obscure error if the incomingScopes HashSet is null or empty.

I believe that the behavior for this case should be unchanged from before this commit, and that the method should return new Scope( getSourceFields() ) and not throw an exception, but it's possible I'm misunderstanding the code.  If the code should throw an exception, I recommend that the the null and/or empty argument cases should be handled by throwing dedicated FlowException(s).

Code compiles and all tests run green.  I've also tried to match the style (braces, etc.) used in the rest of the source code.

Ideally I'd like to see this in 2.0.4, so I can update cascading.ruby to use a production release.  Thoughts?  
