### PR TITLE
Fix Cascading local mode tap initialization bug

### DIFF
--- a/src/local/cascading/flow/local/LocalFlowProcess.java
+++ b/src/local/cascading/flow/local/LocalFlowProcess.java
@@ -58,6 +58,13 @@ public class LocalFlowProcess extends FlowProcess<Properties>
     this.config = config;
     }
 
+  public LocalFlowProcess( LocalFlowProcess flowProcess, Properties properties )
+    {
+      super( flowProcess.getCurrentSession() );
+      this.config = properties;
+      this.stepStats = flowProcess.stepStats;
+    }
+
   public void setStepStats( LocalStepStats stepStats )
     {
     this.stepStats = stepStats;

--- a/src/local/cascading/flow/local/LocalFlowStep.java
+++ b/src/local/cascading/flow/local/LocalFlowStep.java
@@ -40,6 +40,9 @@ public class LocalFlowStep extends BaseFlowStep<Properties>
   /** Field mapperTraps */
   private final Map<String, Tap> traps = new HashMap<String, Tap>();
 
+  /** Map of Properties modified by each Tap's sourceConfInit/sinkConfInit */
+  private final Map<Tap, Properties> tapProperties = new HashMap<Tap, Properties>();
+
   public LocalFlowStep( String name, int id )
     {
     super( name, id );
@@ -65,10 +68,15 @@ public class LocalFlowStep extends BaseFlowStep<Properties>
       {
       for( Tap tap : taps )
         {
+        assert !tapProperties.containsKey(tap) : "Already set properties for tap in this step: " + tap;
+
+        Properties confCopy = flowProcess.copyConfig( conf );
+        tapProperties.put(tap, confCopy);
+
         if( isSink )
-          tap.sinkConfInit( flowProcess, conf );
+          tap.sinkConfInit( flowProcess, confCopy );
         else
-          tap.sourceConfInit( flowProcess, conf );
+          tap.sourceConfInit( flowProcess, confCopy );
         }
       }
     }
@@ -136,6 +144,11 @@ public class LocalFlowStep extends BaseFlowStep<Properties>
   public Map<String, Tap> getTrapMap()
     {
     return traps;
+    }
+
+  public Map<Tap, Properties> getPropertiesMap()
+    {
+    return tapProperties;
     }
 
   @Override

--- a/src/local/cascading/flow/local/LocalFlowStep.java
+++ b/src/local/cascading/flow/local/LocalFlowStep.java
@@ -63,14 +63,12 @@ public class LocalFlowStep extends BaseFlowStep<Properties>
     {
     if( !taps.isEmpty() )
       {
-      Properties confCopy = flowProcess.copyConfig( conf );
-
       for( Tap tap : taps )
         {
         if( isSink )
-          tap.sinkConfInit( flowProcess, confCopy );
+          tap.sinkConfInit( flowProcess, conf );
         else
-          tap.sourceConfInit( flowProcess, confCopy );
+          tap.sourceConfInit( flowProcess, conf );
         }
       }
     }

--- a/src/local/cascading/flow/local/stream/LocalStepStreamGraph.java
+++ b/src/local/cascading/flow/local/stream/LocalStepStreamGraph.java
@@ -20,15 +20,18 @@
 
 package cascading.flow.local.stream;
 
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Properties;
 
 import cascading.flow.FlowElement;
 import cascading.flow.FlowProcess;
+import cascading.flow.local.LocalFlowProcess;
 import cascading.flow.local.LocalFlowStep;
 import cascading.flow.stream.Duct;
 import cascading.flow.stream.Gate;
 import cascading.flow.stream.MemoryCoGroupGate;
+import cascading.flow.stream.SinkStage;
 import cascading.flow.stream.SourceStage;
 import cascading.flow.stream.StepStreamGraph;
 import cascading.pipe.CoGroup;
@@ -59,7 +62,7 @@ public class LocalStepStreamGraph extends StepStreamGraph
     {
     for( Object rhsElement : step.getSources() )
       {
-      Duct rhsDuct = new SourceStage( flowProcess, (Tap) rhsElement );
+      Duct rhsDuct = new SourceStage( tapFlowProcess( (Tap) rhsElement ), (Tap) rhsElement );
 
       addHead( rhsDuct );
 
@@ -83,6 +86,26 @@ public class LocalStepStreamGraph extends StepStreamGraph
     return new SyncMergeStage( flowProcess, merge );
     }
 
+  @Override
+  protected SinkStage createSinkStage( Tap element )
+    {
+    return new SinkStage( tapFlowProcess( (Tap) element ), (Tap) element );
+    }
+
+  private LocalFlowProcess tapFlowProcess(Tap tap)
+    {
+    Properties priorConfig = ( (LocalFlowStep) step ).getPropertiesMap().get(tap);
+    Properties tapProperties = ( (LocalFlowProcess) flowProcess ).getConfigCopy();
+
+    Enumeration<?> keys = priorConfig.propertyNames();
+    while ( keys.hasMoreElements() )
+      {
+      String key = (String) keys.nextElement();
+      tapProperties.setProperty( key, (String) priorConfig.getProperty( key ) );
+      }
+
+    return new LocalFlowProcess( (LocalFlowProcess) flowProcess, tapProperties );
+    }
 
   protected boolean stopOnElement( FlowElement lhsElement, List<FlowElement> successors )
     {

--- a/src/test/cascading/tap/local/LocalTapPlatformTest.java
+++ b/src/test/cascading/tap/local/LocalTapPlatformTest.java
@@ -22,19 +22,32 @@ package cascading.tap.local;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.LineNumberReader;
+import java.io.OutputStream;
 import java.io.PrintStream;
+import java.io.PrintWriter;
 import java.io.Serializable;
+import java.util.Properties;
 
 import cascading.PlatformTestCase;
 import cascading.flow.Flow;
+import cascading.flow.FlowProcess;
 import cascading.flow.local.LocalFlowConnector;
 import cascading.pipe.Pipe;
+import cascading.scheme.Scheme;
+import cascading.scheme.SinkCall;
+import cascading.scheme.SourceCall;
 import cascading.scheme.local.TextLine;
 import cascading.tap.Tap;
+import cascading.tap.SinkMode;
 import cascading.test.LocalPlatform;
 import cascading.test.PlatformRunner;
 import cascading.tuple.Fields;
 import org.junit.Test;
+
+import static data.InputData.inputFileNums20;
 
 /**
  *
@@ -61,5 +74,114 @@ public class LocalTapPlatformTest extends PlatformTestCase implements Serializab
     flow.complete();
 
     assertEquals( lines, output.toString() );
+    }
+
+  /**
+   * Extension of TextLine that actually sets properties.
+   */
+  private static class SchemeWithProperties extends TextLine
+    {
+      public SchemeWithProperties( Fields sourceFields )
+        {
+        super( sourceFields );
+        }
+
+      @Override
+      public void sourceConfInit( FlowProcess<Properties> flowProcess, Tap<Properties, InputStream, OutputStream> tap, Properties conf )
+        {
+        if( !"connector-default".equals( flowProcess.getProperty( "default" ) ) )
+          throw new RuntimeException( "not default value" );
+
+        conf.setProperty("replace", "source-replace");
+        conf.setProperty("local", "source-local");
+        super.sourceConfInit( flowProcess, tap, conf );
+        }
+
+      @Override
+      public void sinkConfInit( FlowProcess<Properties> flowProcess, Tap<Properties, InputStream, OutputStream> tap, Properties conf )
+        {
+        if( !"connector-default".equals( flowProcess.getProperty( "default" ) ) )
+          throw new RuntimeException( "not default value" );
+
+        conf.setProperty("replace", "sink-replace");
+        conf.setProperty("local", "sink-local");
+        super.sinkConfInit( flowProcess, tap, conf );
+        }
+
+      @Override
+      public void sourcePrepare( FlowProcess<Properties> flowProcess, SourceCall<LineNumberReader, InputStream> sourceCall ) throws IOException
+        {
+        if( !"connector-default".equals( flowProcess.getProperty( "default" ) ) )
+          throw new RuntimeException( "not default value" );
+
+        if( !"source-replace".equals( flowProcess.getProperty( "replace" ) ) )
+          throw new RuntimeException( "not replaced value" );
+
+        if( !"source-local".equals( flowProcess.getProperty( "local" ) ) )
+          throw new RuntimeException( "not local value" );
+
+        super.sourcePrepare( flowProcess, sourceCall );
+        }
+
+      @Override
+      public void sinkPrepare( FlowProcess<Properties> flowProcess, SinkCall<PrintWriter, OutputStream> sinkCall ) throws IOException
+        {
+        if( !"connector-default".equals( flowProcess.getProperty( "default" ) ) )
+          throw new RuntimeException( "not default value" );
+
+        if( !"sink-replace".equals( flowProcess.getProperty( "replace" ) ) )
+          throw new RuntimeException( "not replaced value" );
+
+        if( !"sink-local".equals( flowProcess.getProperty( "local" ) ) )
+          throw new RuntimeException( "not local value" );
+
+        super.sinkPrepare( flowProcess, sinkCall );
+        }
+    }
+
+  @Test
+  public void testSourceConfInit() throws IOException
+    {
+    getPlatform().copyFromLocal( inputFileNums20 );
+
+    Scheme scheme = new SchemeWithProperties( new Fields( "line" ) );
+    Tap source = getPlatform().getTap( scheme, inputFileNums20, SinkMode.KEEP );
+
+    Pipe pipe = new Pipe( "test" );
+
+    Tap sink = getPlatform().getTextFile( getOutputPath( "sourceconfinit" ), SinkMode.REPLACE );
+
+    Properties properties = new Properties();
+    properties.setProperty("default", "connector-default");
+    properties.setProperty("replace", "connector-replace");
+
+    Flow flow = getPlatform().getFlowConnector(properties).connect( source, sink, pipe );
+
+    flow.complete();
+
+    assertTrue( flow.resourceExists( sink ) );
+    }
+
+  @Test
+  public void testSinkConfInit() throws IOException
+    {
+    getPlatform().copyFromLocal( inputFileNums20 );
+
+    Tap source = getPlatform().getTextFile( new Fields( "line" ), inputFileNums20, SinkMode.KEEP );
+
+    Pipe pipe = new Pipe( "test" );
+
+    Scheme scheme = new SchemeWithProperties( new Fields( "line" ) );
+    Tap sink = getPlatform().getTap( scheme, getOutputPath( "sinkconfinit" ), SinkMode.REPLACE );
+
+    Properties properties = new Properties();
+    properties.setProperty("default", "connector-default");
+    properties.setProperty("replace", "connector-replace");
+
+    Flow flow = getPlatform().getFlowConnector(properties).connect( source, sink, pipe );
+
+    flow.complete();
+
+    assertTrue( flow.resourceExists( sink ) );
     }
   }


### PR DESCRIPTION
I stumbled across this while cleaning up the LocalTap to submit to Cascading/maple.  I took pains to ensure the wrapped scheme was allowed to write into the properties object at configuration time, but found that:
1. None of the local schemes in Cascading now set properties
2. Even if they did, c.f.l.LocalFlowStep#initTaps currently passes a copy into each taps conf method, so the properties set by the scheme wouldn't register

The fix was trivial, but I hope I've unit tested it sufficiently/correctly.  I located the tests in LocalTapPlatformTest, but modeled them after the ConfigDefPlatformTest.
