### PR TITLE
add a check on FileInputFormat.setInputPaths

### DIFF
--- a/src/hadoop/cascading/tap/hadoop/io/MultiInputFormat.java
+++ b/src/hadoop/cascading/tap/hadoop/io/MultiInputFormat.java
@@ -73,7 +73,8 @@ public class MultiInputFormat implements InputFormat
         isLocal = fromJob.get( "mapred.job.tracker" ).equalsIgnoreCase( "local" );
       }
 
-    FileInputFormat.setInputPaths( toJob, (Path[]) allPaths.toArray( new Path[ allPaths.size() ] ) );
+    if( !allPaths.isEmpty() )
+      FileInputFormat.setInputPaths( toJob, (Path[]) allPaths.toArray( new Path[ allPaths.size() ] ) );
 
     try
       {


### PR DESCRIPTION
if we use InputFormat classes that don't use the filesystem, and thus don't set "mapred.input.dir", we end up with :

```
Exception in thread "main" cascading.flow.planner.PlannerException: could not build flow from assembly: [0]
    at cascading.flow.planner.FlowPlanner.handleExceptionDuringPlanning(FlowPlanner.java:515)
    at cascading.flow.hadoop.planner.HadoopPlanner.buildFlow(HadoopPlanner.java:230)
    at cascading.flow.FlowConnector.connect(FlowConnector.java:454)
Caused by: java.lang.ArrayIndexOutOfBoundsException: 0
    at org.apache.hadoop.mapred.FileInputFormat.setInputPaths(FileInputFormat.java:318)
    at cascading.tap.hadoop.io.MultiInputFormat.addInputFormat(MultiInputFormat.java:76)
    at cascading.flow.hadoop.HadoopFlowStep.initFromSources(HadoopFlowStep.java:345)
    at cascading.flow.hadoop.HadoopFlowStep.getInitializedConfig(HadoopFlowStep.java:98)
    at cascading.flow.hadoop.HadoopFlowStep.createFlowStepJob(HadoopFlowStep.java:200)
    at cascading.flow.hadoop.HadoopFlowStep.createFlowStepJob(HadoopFlowStep.java:68)
    at cascading.flow.planner.BaseFlowStep.getFlowStepJob(BaseFlowStep.java:588)
    at cascading.flow.BaseFlow.initializeNewJobsMap(BaseFlow.java:1162)
    at cascading.flow.BaseFlow.initialize(BaseFlow.java:184)
    at cascading.flow.hadoop.planner.HadoopPlanner.buildFlow(HadoopPlanner.java:224)
```

So the MultiInputFormat should not try to set an empty array of paths on FileInputFormat.
