### PR TITLE
Bug in Fields.append(Fields[] fields)

### DIFF
--- a/cascading-core/src/main/java/cascading/tuple/Fields.java
+++ b/cascading-core/src/main/java/cascading/tuple/Fields.java
@@ -1013,9 +1013,9 @@ public class Fields implements Comparable, Iterable<Comparable>, Serializable, C
     if( fields.length == 0 )
       return null;
 
-    Fields field = fields[ 0 ];
+    Fields field = this;
 
-    for( int i = 1; i < fields.length; i++ )
+    for( int i = 0; i < fields.length; i++ )
       field = field.append( fields[ i ] );
 
     return field;

--- a/cascading-core/src/test/java/cascading/tuple/FieldsTest.java
+++ b/cascading-core/src/test/java/cascading/tuple/FieldsTest.java
@@ -51,6 +51,58 @@ public class FieldsTest extends CascadingTestCase
       }
     }
 
+  public void testAppendArray()
+    {
+    Fields fieldA = new Fields(0);
+    Fields[] fieldArray = {new Fields(0), new Fields(1)};
+
+    Fields appended = fieldA.append(fieldArray);
+
+    assertEquals("not equal: ", 3, appended.size());
+    assertEquals("not equal: ", 0, appended.get(0));
+    assertEquals("not equal: ", 1, appended.get(1));
+    assertEquals("not equal: ", 2, appended.get(2));
+    }
+
+  public void testAppendArray2()
+    {
+    Fields fieldA = new Fields(0);
+    Fields [] fieldArray = {new Fields(1),new Fields(2)};
+
+    Fields appended = fieldA.append( fieldArray );
+
+    assertEquals("not equal: ", 3, appended.size());
+    assertEquals("not equal: ", 0, appended.get(0));
+    assertEquals("not equal: ", 1, appended.get(1));
+    assertEquals("not equal: ", 2, appended.get(2));
+    }
+
+  public void testAppendArrayNamed()
+    {
+    Fields fieldA = new Fields("a");
+    Fields[] fieldArray = {new Fields("b"), new Fields("c")};
+
+    Fields appended = fieldA.append(fieldArray);
+
+    assertEquals("not equal: ", 3, appended.size());
+    assertEquals("not equal: ", "a", appended.get(0));
+    assertEquals("not equal: ", "b", appended.get(1));
+    assertEquals("not equal: ", "c", appended.get(2));
+    }
+
+  public void testAppendArrayNamed2()
+    {
+    Fields fieldA = new Fields("a");
+    Fields[] fieldArray = {new Fields(0), new Fields(1)};
+
+    Fields appended = fieldA.append(fieldArray);
+
+    assertEquals("not equal: ", 3, appended.size());
+    assertEquals("not equal: ", "a", appended.get(0));
+    assertEquals("not equal: ", 1, appended.get(1));
+    assertEquals("not equal: ", 2, appended.get(2));
+    }
+
   public void testAppend()
     {
     Fields fieldA = new Fields( 0, 1 );


### PR DESCRIPTION
Hi!

When appending an array of fields to an existing Fields object, the existing Fields object is not included in the returned object.

Example:

``` java
Fields fieldA = new Fields("a");
Fields[] fieldArray = {new Fields("b"), new Fields("c")};

// appended only includes "b", and "c"
Fields appended = fieldA.append(fieldArray);
```

This pull request includes the fix and some tests.
