### PR TITLE
Fix for inconsistency in converting to Integer (or Long or Short) from Numeric and String

### DIFF
--- a/cascading-core/src/main/java/cascading/tuple/Tuples.java
+++ b/cascading-core/src/main/java/cascading/tuple/Tuples.java
@@ -173,7 +173,11 @@ public class Tuples
     else if( value == null )
       return 0;
     else
-      return Integer.parseInt( value.toString() );
+      try {
+        return Integer.parseInt( value.toString() );
+      } catch (NumberFormatException e) {
+        return Double.valueOf( value.toString() ).intValue();
+      }
     }
 
   public static final long toLong( Object value )
@@ -183,7 +187,11 @@ public class Tuples
     else if( value == null )
       return 0;
     else
-      return Long.parseLong( value.toString() );
+      try {
+        return Long.parseLong( value.toString() );
+      } catch (NumberFormatException e) {
+        return Double.valueOf( value.toString() ).longValue();
+      }
     }
 
   public static final double toDouble( Object value )
@@ -213,7 +221,11 @@ public class Tuples
     else if( value == null )
       return 0;
     else
-      return Short.parseShort( value.toString() );
+      try {
+        return Short.parseShort( value.toString() );
+      } catch (NumberFormatException e) {
+        return Double.valueOf( value.toString() ).shortValue();
+      }
     }
 
   public static final boolean toBoolean( Object value )
@@ -233,7 +245,11 @@ public class Tuples
     else if( value == null || value.toString().isEmpty() )
       return null;
     else
-      return Integer.parseInt( value.toString() );
+      try {
+        return Integer.parseInt( value.toString() );
+      } catch (NumberFormatException e) {
+        return Double.valueOf( value.toString() ).intValue();
+      }
     }
 
   public static final Long toLongObject( Object value )
@@ -243,7 +259,11 @@ public class Tuples
     else if( value == null || value.toString().isEmpty() )
       return null;
     else
-      return Long.parseLong( value.toString() );
+      try {
+        return Long.parseLong( value.toString() );
+      } catch (NumberFormatException e) {
+        return Double.valueOf( value.toString() ).longValue();
+      }
     }
 
   public static final Double toDoubleObject( Object value )
@@ -273,7 +293,11 @@ public class Tuples
     else if( value == null || value.toString().isEmpty() )
       return 0;
     else
-      return Short.parseShort( value.toString() );
+      try {
+        return Short.parseShort( value.toString() );
+      } catch (NumberFormatException e) {
+        return Double.valueOf( value.toString() ).shortValue();
+      }
     }
 
   public static final Boolean toBooleanObject( Object value )

--- a/cascading-core/src/test/java/cascading/tuple/TupleTest.java
+++ b/cascading-core/src/test/java/cascading/tuple/TupleTest.java
@@ -284,6 +284,30 @@ public class TupleTest extends CascadingTestCase
     assertEquals( results.getObject( 3 ), date.toString() );
     }
 
+  public void testCoerceInteger()
+    {
+    Tuple tuple = new Tuple( 1, "1", null, 1.9F, "1.9" );
+    Tuple results = Tuples.coerce( tuple, new Class[]{int.class, int.class, int.class, int.class, int.class} );
+
+    assertEquals( results.getObject( 0 ), 1 );
+    assertEquals( results.getObject( 1 ), 1 );
+    assertEquals( results.getObject( 2 ), 0 );
+    assertEquals( results.getObject( 3 ), 1 );
+    assertEquals( results.getObject( 4 ), 1 );
+    }
+
+  public void testCoerceIntegerObject()
+    {
+    Tuple tuple = new Tuple( 1, "1", null, 1.9F, "1.9" );
+    Tuple results = Tuples.coerce( tuple, new Class[]{Integer.class, Integer.class, Integer.class, Integer.class, Integer.class} );
+
+    assertEquals( results.getObject( 0 ), 1 );
+    assertEquals( results.getObject( 1 ), 1 );
+    assertEquals( results.getObject( 2 ), null );
+    assertEquals( results.getObject( 3 ), 1 );
+    assertEquals( results.getObject( 4 ), 1 );
+    }
+      
   public void testSetAll()
     {
     Tuple aTuple = new Tuple( tuple );


### PR DESCRIPTION
I noticed that the code for Tuples.toInteger is not entirely consistent.
For example Tuples.toInteger(71) and Tuples.toInteger("71") give the same result.
But Tuples.toInteger(71.5) will work while Tuples.toInteger("71.5") will throw an exception.
