### PR TITLE
Remove trailing "]" from tap identifier.

### DIFF
--- a/cascading-core/src/main/java/cascading/util/Util.java
+++ b/cascading-core/src/main/java/cascading/util/Util.java
@@ -303,7 +303,7 @@ public class Util
     if( url == null )
       return null;
 
-    return url.replaceAll( "(?<=//).*:.*@", "" ) + "\"]";
+    return url.replaceAll( "(?<=//).*:.*@", "" );
     }
 
   /**

--- a/cascading-core/src/test/java/cascading/UtilTest.java
+++ b/cascading-core/src/test/java/cascading/UtilTest.java
@@ -96,4 +96,10 @@ public class UtilTest
       assertEquals( paths[ i ], versions[ i ], Util.findVersion( paths[ i ] ) );
       }
     }
+      
+    @Test
+    public void testSanitizeUrl ()
+    {
+      assertEquals ( "file://localhost/myFile.txt", Util.sanitizeUrl ( "file://username:password@localhost/myFile.txt" ) );
+    }
   }


### PR DESCRIPTION
I noticed there's a trailing "\"]" in the string representation of a tap. I don't think it affects anything functionally, but it does tend to confuse things when trying to explore in e.g., a Clojure repl (which is where I noticed it). Cheers, David
