### PR TITLE
enable support for CombineFileInputFormat

### DIFF
--- a/cascading-hadoop/src/main/java/cascading/tap/hadoop/CombinedHfs.java
+++ b/cascading-hadoop/src/main/java/cascading/tap/hadoop/CombinedHfs.java
@@ -106,17 +106,17 @@ public class CombinedHfs extends SourceTap<JobConf,RecordReader> implements File
     return hfs.getFullIdentifier( conf );
     }
 
-  public boolean isDirectory(JobConf conf) throws IOException
+  public boolean isDirectory( JobConf conf ) throws IOException
     {
     return hfs.isDirectory( conf );
     }
 
-  public String[] getChildIdentifiers(JobConf conf) throws IOException
+  public String[] getChildIdentifiers( JobConf conf ) throws IOException
     {
     return hfs.getChildIdentifiers( conf );
     }
 
-  public long getSize(JobConf conf) throws IOException
+  public long getSize( JobConf conf ) throws IOException
     {
     return hfs.getSize( conf );
     }
@@ -124,7 +124,6 @@ public class CombinedHfs extends SourceTap<JobConf,RecordReader> implements File
   /**
    * Returns the underlying Hfs instance.
    */
-  // sjlee - not sure if this will be needed
   public Hfs getHfs()
     {
     return hfs;

--- a/cascading-hadoop/src/main/java/cascading/tap/hadoop/CombinedHfs.java
+++ b/cascading-hadoop/src/main/java/cascading/tap/hadoop/CombinedHfs.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.mapred.lib.CombineFileSplit;
 import cascading.flow.FlowProcess;
 import cascading.tap.SourceTap;
 import cascading.tap.hadoop.io.CombineFileRecordReaderWrapper;
+import cascading.tap.hadoop.io.HadoopTupleEntrySchemeIterator;
 import cascading.tap.type.FileType;
 import cascading.tuple.TupleEntryIterator;
 
@@ -53,6 +54,7 @@ public class CombinedHfs extends SourceTap<JobConf,RecordReader> implements File
 
   public CombinedHfs( Hfs hfs )
     {
+    super( hfs.getScheme() );
     this.hfs = hfs;
     }
 
@@ -64,7 +66,7 @@ public class CombinedHfs extends SourceTap<JobConf,RecordReader> implements File
   public TupleEntryIterator openForRead( FlowProcess<JobConf> flowProcess, RecordReader input )
     throws IOException
     {
-    return hfs.openForRead( flowProcess, input );
+    return new HadoopTupleEntrySchemeIterator( flowProcess, this, input );
     }
 
   public boolean resourceExists( JobConf conf ) throws IOException

--- a/cascading-hadoop/src/main/java/cascading/tap/hadoop/CombinedHfs.java
+++ b/cascading-hadoop/src/main/java/cascading/tap/hadoop/CombinedHfs.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2007-2013 Concurrent, Inc. All Rights Reserved.
+ *
+ * Project and contact information: http://www.cascading.org/
+ *
+ * This file is part of the Cascading project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cascading.tap.hadoop;
+
+import java.io.IOException;
+
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.hadoop.mapred.lib.CombineFileInputFormat;
+import org.apache.hadoop.mapred.lib.CombineFileRecordReader;
+import org.apache.hadoop.mapred.lib.CombineFileSplit;
+
+import cascading.flow.FlowProcess;
+import cascading.tap.SourceTap;
+import cascading.tap.hadoop.io.CombineFileRecordReaderWrapper;
+import cascading.tap.type.FileType;
+import cascading.tuple.TupleEntryIterator;
+
+/**
+ * CombinedHfs can be used in lieu of {@link Hfs} when a number of input files should be combined to form bigger
+ * hadoop splits. Like {@link Hfs}, CombinedHfs may only be used with the
+ * {@link cascading.flow.hadoop.HadoopFlowConnector} when creating Hadoop executable {@link cascading.flow.Flow}
+ * instances.
+ * <p/>
+ * A CombinedHfs is a wrapper around {@link Hfs}. Create an {@link Hfs} instance, set property
+ * <code>cascading.individual.input.format</code>, and wrap the {@link Hfs} instance.
+ *
+ * @see org.apache.hadoop.mapred.lib.CombineFileInputFormat
+ */
+public class CombinedHfs extends SourceTap<JobConf,RecordReader> implements FileType<JobConf>
+  {
+  private final Hfs hfs;
+
+  public CombinedHfs( Hfs hfs )
+    {
+    this.hfs = hfs;
+    }
+
+  public String getIdentifier()
+    {
+    return hfs.getIdentifier();
+    }
+
+  public TupleEntryIterator openForRead( FlowProcess<JobConf> flowProcess, RecordReader input )
+    throws IOException
+    {
+    return hfs.openForRead( flowProcess, input );
+    }
+
+  public boolean resourceExists( JobConf conf ) throws IOException
+    {
+    return hfs.resourceExists( conf );
+    }
+
+  public long getModifiedTime( JobConf conf ) throws IOException
+    {
+    return hfs.getModifiedTime( conf );
+    }
+
+  @Override
+  public void sourceConfInit( FlowProcess<JobConf> flowProcess, JobConf conf )
+    {
+    // let the hfs does its thing first
+    hfs.sourceConfInit( flowProcess, conf );
+    if ( !CombineFileRecordReaderWrapper.individualInputFormatSet( conf ) )
+      {
+      throw new IllegalArgumentException( "the job configuration does not have the individual input format set on a CombineHfs" );
+      }
+
+    // override the input format class
+    conf.setInputFormat( CombinedInputFormat.class );
+    }
+
+  @Override
+  public String getFullIdentifier( JobConf conf )
+    {
+    return hfs.getFullIdentifier( conf );
+    }
+
+  public boolean isDirectory(JobConf conf) throws IOException
+    {
+    return hfs.isDirectory( conf );
+    }
+
+  public String[] getChildIdentifiers(JobConf conf) throws IOException
+    {
+    return hfs.getChildIdentifiers( conf );
+    }
+
+  public long getSize(JobConf conf) throws IOException
+    {
+    return hfs.getSize( conf );
+    }
+
+  /**
+   * Returns the underlying Hfs instance.
+   */
+  // sjlee - not sure if this will be needed
+  public Hfs getHfs()
+    {
+    return hfs;
+    }
+  }
+
+/**
+ * Combined input format that uses the underlying individual input format to combine multiple files into a single split.
+ */
+class CombinedInputFormat extends CombineFileInputFormat
+  {
+  public RecordReader getRecordReader( InputSplit split, JobConf job, Reporter reporter )
+    throws IOException
+    {
+    return new CombineFileRecordReader( job, (CombineFileSplit) split, reporter, CombineFileRecordReaderWrapper.class );
+    }
+  }

--- a/cascading-hadoop/src/main/java/cascading/tap/hadoop/io/CombineFileRecordReaderWrapper.java
+++ b/cascading-hadoop/src/main/java/cascading/tap/hadoop/io/CombineFileRecordReaderWrapper.java
@@ -50,10 +50,10 @@ public class CombineFileRecordReaderWrapper<K,V> implements RecordReader<K,V>
   // this constructor signature is required by CombineFileRecordReader
   public CombineFileRecordReaderWrapper( CombineFileSplit split, Configuration conf, Reporter reporter, Integer idx ) throws Exception
     {
-    FileSplit fileSplit = new FileSplit(split.getPath(idx),
-        split.getOffset(idx),
-        split.getLength(idx),
-        split.getLocations());
+    FileSplit fileSplit = new FileSplit( split.getPath( idx ),
+        split.getOffset( idx ),
+        split.getLength( idx ),
+        split.getLocations() );
  
     Class<?> clz = conf.getClass( INDIVIDUAL_INPUT_FORMAT, null );
     FileInputFormat<K,V> inputFormat = (FileInputFormat<K,V>) clz.newInstance();

--- a/cascading-hadoop/src/main/java/cascading/tap/hadoop/io/CombineFileRecordReaderWrapper.java
+++ b/cascading-hadoop/src/main/java/cascading/tap/hadoop/io/CombineFileRecordReaderWrapper.java
@@ -56,7 +56,7 @@ public class CombineFileRecordReaderWrapper<K,V> implements RecordReader<K,V>
         split.getLength(idx),
         split.getLocations());
  
-    Class<?> clz = conf.getClassByName( INDIVIDUAL_INPUT_FORMAT );
+    Class<?> clz = conf.getClass( INDIVIDUAL_INPUT_FORMAT, null );
     FileInputFormat<K,V> inputFormat = (FileInputFormat<K,V>) clz.newInstance();
     delegate = inputFormat.getRecordReader( fileSplit, (JobConf) conf, reporter );
     }

--- a/cascading-hadoop/src/main/java/cascading/tap/hadoop/io/CombineFileRecordReaderWrapper.java
+++ b/cascading-hadoop/src/main/java/cascading/tap/hadoop/io/CombineFileRecordReaderWrapper.java
@@ -61,14 +61,6 @@ public class CombineFileRecordReaderWrapper<K,V> implements RecordReader<K,V>
     delegate = inputFormat.getRecordReader( fileSplit, (JobConf) conf, reporter );
     }
 
-  /**
-   * Returns whether the individual input format is set with {@link #INDIVIDUAL_INPUT_FORMAT}.
-   */
-  public static boolean individualInputFormatSet( Configuration conf )
-    {
-    return conf.get( INDIVIDUAL_INPUT_FORMAT ) != null;
-    }
-
   public boolean next( K key, V value ) throws IOException
     {
     return delegate.next( key, value );

--- a/cascading-hadoop/src/main/java/cascading/tap/hadoop/io/CombineFileRecordReaderWrapper.java
+++ b/cascading-hadoop/src/main/java/cascading/tap/hadoop/io/CombineFileRecordReaderWrapper.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2007-2013 Concurrent, Inc. All Rights Reserved.
+ *
+ * Project and contact information: http://www.cascading.org/
+ *
+ * This file is part of the Cascading project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cascading.tap.hadoop.io;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.hadoop.mapred.lib.CombineFileSplit;
+
+/**
+ * A wrapper class for a record reader that handles a single file split. It delegates most of the
+ * methods to the wrapped instance. We need this wrapper to satisfy the constructor requirement to
+ * be used with hadoop's CombineFileRecordReader class.
+ *
+ * @see org.apache.hadoop.mapred.lib.CombineFileRecordReader
+ * @see org.apache.hadoop.mapred.lib.CombineFileInputFormat
+ */
+public class CombineFileRecordReaderWrapper<K,V> implements RecordReader<K,V>
+  {
+  /**
+   * property that indicates how individual input format is to be interpreted
+   */
+  public static final String INDIVIDUAL_INPUT_FORMAT = "cascading.individual.input.format";
+
+  private final RecordReader<K,V> delegate;
+
+  // this constructor signature is required by CombineFileRecordReader
+  public CombineFileRecordReaderWrapper( CombineFileSplit split, Configuration conf, Reporter reporter, Integer idx )
+    throws IOException, ReflectiveOperationException
+    {
+    FileSplit fileSplit = new FileSplit(split.getPath(idx),
+        split.getOffset(idx),
+        split.getLength(idx),
+        split.getLocations());
+ 
+    Class<?> clz = conf.getClassByName( INDIVIDUAL_INPUT_FORMAT );
+    FileInputFormat<K,V> inputFormat = (FileInputFormat<K,V>) clz.newInstance();
+    delegate = inputFormat.getRecordReader( fileSplit, (JobConf) conf, reporter );
+    }
+
+  /**
+   * Returns whether the individual input format is set with {@link #INDIVIDUAL_INPUT_FORMAT}.
+   */
+  public static boolean individualInputFormatSet( Configuration conf )
+    {
+    return conf.get( INDIVIDUAL_INPUT_FORMAT ) != null;
+    }
+
+  public boolean next( K key, V value ) throws IOException
+    {
+    return delegate.next( key, value );
+    }
+
+  public K createKey()
+    {
+    return delegate.createKey();
+    }
+
+  public V createValue()
+    {
+    return delegate.createValue();
+    }
+
+  public long getPos() throws IOException
+    {
+    return delegate.getPos();
+    }
+
+  public void close() throws IOException
+    {
+    delegate.close();
+    }
+
+  public float getProgress() throws IOException
+    {
+    return delegate.getProgress();
+    }
+  }

--- a/cascading-hadoop/src/main/java/cascading/tap/hadoop/io/CombineFileRecordReaderWrapper.java
+++ b/cascading-hadoop/src/main/java/cascading/tap/hadoop/io/CombineFileRecordReaderWrapper.java
@@ -48,8 +48,7 @@ public class CombineFileRecordReaderWrapper<K,V> implements RecordReader<K,V>
   private final RecordReader<K,V> delegate;
 
   // this constructor signature is required by CombineFileRecordReader
-  public CombineFileRecordReaderWrapper( CombineFileSplit split, Configuration conf, Reporter reporter, Integer idx )
-    throws IOException, ReflectiveOperationException
+  public CombineFileRecordReaderWrapper( CombineFileSplit split, Configuration conf, Reporter reporter, Integer idx ) throws Exception
     {
     FileSplit fileSplit = new FileSplit(split.getPath(idx),
         split.getOffset(idx),

--- a/cascading-hadoop/src/test/java/cascading/tap/hadoop/HadoopTapPlatformTest.java
+++ b/cascading-hadoop/src/test/java/cascading/tap/hadoop/HadoopTapPlatformTest.java
@@ -33,6 +33,7 @@ import cascading.cascade.Cascade;
 import cascading.cascade.CascadeConnector;
 import cascading.flow.Flow;
 import cascading.flow.FlowProcess;
+import cascading.flow.FlowSession;
 import cascading.flow.hadoop.HadoopFlowConnector;
 import cascading.flow.hadoop.HadoopFlowProcess;
 import cascading.flow.hadoop.planner.HadoopPlanner;
@@ -54,6 +55,7 @@ import cascading.scheme.hadoop.TextLine;
 import cascading.tap.MultiSourceTap;
 import cascading.tap.SinkMode;
 import cascading.tap.Tap;
+import cascading.tap.hadoop.io.CombineFileRecordReaderWrapper;
 import cascading.tuple.Fields;
 import cascading.tuple.Tuple;
 import cascading.tuple.TupleEntryIterator;
@@ -61,6 +63,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputCollector;
 import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.TextInputFormat;
 import org.junit.Test;
 
 import static data.InputData.*;
@@ -452,6 +455,23 @@ public class HadoopTapPlatformTest extends PlatformTestCase implements Serializa
       {
       // do nothing
       }
+    }
+
+  @Test
+  public void testCombinedHfs() throws Exception
+    {
+    String dataLocation = System.getProperty( data.InputData.TEST_DATA_PATH, "src/test/data" );
+
+    // clean up to ensure only two files exist
+    getPlatform().remoteRemove(dataLocation, true);
+
+    getPlatform().copyFromLocal( inputFileLower );
+    getPlatform().copyFromLocal( inputFileUpper );
+
+    // create a CombinedHfs instance on the directory location
+    CombinedHfs source = new CombinedHfs( new Hfs( new TextLine( new Fields( "offset", "line" )), dataLocation ), TextInputFormat.class );
+
+    validateLength( source.openForRead( getPlatform().getFlowProcess() ), 10 );
     }
 
   public class DupeConfigScheme extends TextLine

--- a/cascading-hadoop/src/test/java/cascading/tap/hadoop/HadoopTapPlatformTest.java
+++ b/cascading-hadoop/src/test/java/cascading/tap/hadoop/HadoopTapPlatformTest.java
@@ -20,6 +20,11 @@
 
 package cascading.tap.hadoop;
 
+import static data.InputData.inputFileApache;
+import static data.InputData.inputFileComments;
+import static data.InputData.inputFileLower;
+import static data.InputData.inputFileUpper;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
@@ -28,12 +33,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.OutputCollector;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.TextInputFormat;
+import org.junit.Test;
+
 import cascading.PlatformTestCase;
 import cascading.cascade.Cascade;
 import cascading.cascade.CascadeConnector;
 import cascading.flow.Flow;
 import cascading.flow.FlowProcess;
-import cascading.flow.FlowSession;
 import cascading.flow.hadoop.HadoopFlowConnector;
 import cascading.flow.hadoop.HadoopFlowProcess;
 import cascading.flow.hadoop.planner.HadoopPlanner;
@@ -55,18 +66,9 @@ import cascading.scheme.hadoop.TextLine;
 import cascading.tap.MultiSourceTap;
 import cascading.tap.SinkMode;
 import cascading.tap.Tap;
-import cascading.tap.hadoop.io.CombineFileRecordReaderWrapper;
 import cascading.tuple.Fields;
 import cascading.tuple.Tuple;
 import cascading.tuple.TupleEntryIterator;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.mapred.JobConf;
-import org.apache.hadoop.mapred.OutputCollector;
-import org.apache.hadoop.mapred.RecordReader;
-import org.apache.hadoop.mapred.TextInputFormat;
-import org.junit.Test;
-
-import static data.InputData.*;
 
 /**
  *


### PR DESCRIPTION
This enables support for CombineFileInputFormat in hadoop. CombineFileInputFormat combines a number of small files into a larger split, and improves performance in some situations.
