### PR TITLE
Wip 2.1

### DIFF
--- a/cascading-core/src/main/java/cascading/flow/BaseFlow.java
+++ b/cascading-core/src/main/java/cascading/flow/BaseFlow.java
@@ -156,7 +156,6 @@ public abstract class BaseFlow<Config> implements Flow<Config>
     this.name = name;
     addSessionProperties( properties );
     initConfig( properties, defaultConfig );
-    initFromProperties( properties );
 
     this.flowStats = createPrepareFlowStats(); // must be last
     }
@@ -174,7 +173,6 @@ public abstract class BaseFlow<Config> implements Flow<Config>
     setSinks( flowDef.getSinksCopy() );
     setTraps( flowDef.getTrapsCopy() );
     setCheckpoints( flowDef.getCheckpointsCopy() );
-    initFromProperties( properties );
     initFromTaps();
 
     retrieveSourceFields();

--- a/cascading-core/src/main/java/cascading/tuple/Fields.java
+++ b/cascading-core/src/main/java/cascading/tuple/Fields.java
@@ -694,6 +694,10 @@ public class Fields implements Comparable, Iterable<Comparable>, Serializable, C
       {
       Comparable field = fields[ i ];
 
+      if (!(field instanceof String || field instanceof Integer )) {
+        throw new IllegalArgumentException( String.format( "invalid field type (%s); must be String or Integer: ", field ));
+      }
+
       if( field == null )
         throw new IllegalArgumentException( "field name or position may not be null" );
 

--- a/cascading-hadoop/src/main/java/cascading/flow/hadoop/HadoopFlow.java
+++ b/cascading-hadoop/src/main/java/cascading/flow/hadoop/HadoopFlow.java
@@ -81,11 +81,13 @@ public class HadoopFlow extends BaseFlow<JobConf>
   protected HadoopFlow( PlatformInfo platformInfo, Map<Object, Object> properties, JobConf jobConf, String name )
     {
     super( platformInfo, properties, jobConf, name );
+    initProperties(properties);
     }
 
   public HadoopFlow( PlatformInfo platformInfo, Map<Object, Object> properties, JobConf jobConf, FlowDef flowDef )
     {
     super( platformInfo, properties, jobConf, flowDef );
+    initProperties(properties);
     }
 
   protected void initFromProperties( Map<Object, Object> properties )

--- a/cascading-hadoop/src/main/java/cascading/flow/hadoop/HadoopFlow.java
+++ b/cascading-hadoop/src/main/java/cascading/flow/hadoop/HadoopFlow.java
@@ -81,13 +81,13 @@ public class HadoopFlow extends BaseFlow<JobConf>
   protected HadoopFlow( PlatformInfo platformInfo, Map<Object, Object> properties, JobConf jobConf, String name )
     {
     super( platformInfo, properties, jobConf, name );
-    initProperties(properties);
+    initFromProperties(properties);
     }
 
   public HadoopFlow( PlatformInfo platformInfo, Map<Object, Object> properties, JobConf jobConf, FlowDef flowDef )
     {
     super( platformInfo, properties, jobConf, flowDef );
-    initProperties(properties);
+    initFromProperties(properties);
     }
 
   protected void initFromProperties( Map<Object, Object> properties )

--- a/cascading-local/src/main/java/cascading/flow/local/LocalFlow.java
+++ b/cascading-local/src/main/java/cascading/flow/local/LocalFlow.java
@@ -44,7 +44,7 @@ public class LocalFlow extends BaseFlow<Properties>
   public LocalFlow( PlatformInfo platformInfo, Map<Object, Object> properties, Properties config, FlowDef flowDef )
     {
     super( platformInfo, properties, config, flowDef );
-    initProperties(properties);
+    initFromProperties(properties);
     }
 
   @Override

--- a/cascading-local/src/main/java/cascading/flow/local/LocalFlow.java
+++ b/cascading-local/src/main/java/cascading/flow/local/LocalFlow.java
@@ -44,6 +44,7 @@ public class LocalFlow extends BaseFlow<Properties>
   public LocalFlow( PlatformInfo platformInfo, Map<Object, Object> properties, Properties config, FlowDef flowDef )
     {
     super( platformInfo, properties, config, flowDef );
+    initProperties(properties);
     }
 
   @Override


### PR DESCRIPTION
Change so that initialization from base class BaseFlow does not get overwritten in initialization in subclasses HadoopFlow and LocalFlow. See instance variable preserveTemporaryFiles in HadoopFlow in particular. 
