### PR TITLE
ShortObjectCoerce returns null for empty values instead of zero 

### DIFF
--- a/cascading-core/src/main/java/cascading/tuple/coerce/ShortObjectCoerce.java
+++ b/cascading-core/src/main/java/cascading/tuple/coerce/ShortObjectCoerce.java
@@ -45,7 +45,7 @@ public class ShortObjectCoerce extends Coercions.Coerce<Short>
     if( value instanceof Number )
       return ( (Number) value ).shortValue();
     else if( value == null || value.toString().isEmpty() )
-      return 0;
+      return null;
     else
       return Short.parseShort( value.toString() );
     }

--- a/cascading-core/src/test/java/cascading/tuple/coerce/IntegerObjectCoerceTest.java
+++ b/cascading-core/src/test/java/cascading/tuple/coerce/IntegerObjectCoerceTest.java
@@ -1,0 +1,36 @@
+package cascading.tuple.coerce;
+
+import cascading.CascadingTestCase;
+import cascading.tuple.coerce.Coercions.Coerce;
+
+public class IntegerObjectCoerceTest extends CascadingTestCase 
+{
+
+  private final Coerce<Integer> coercion = Coercions.INTEGER_OBJECT;
+
+  public void testCoerceShort() 
+  {
+    assertEquals(new Integer(1), coercion.coerce(new Integer(1)));
+  }
+
+  public void testCoerceNumber() 
+  {
+    assertEquals(new Integer(1), coercion.coerce(new Long(1L)));
+  }
+
+  public void testCoerceString() 
+  {
+    assertEquals(new Integer(1), coercion.coerce("1"));
+  }
+
+  public void testCoerceNull() 
+  {
+    assertEquals(null, coercion.coerce(null));
+  }
+
+  public void testCoerceEmptyString() 
+  {
+    assertEquals(null, coercion.coerce(""));
+  }
+
+}

--- a/cascading-core/src/test/java/cascading/tuple/coerce/ShortObjectCoerceTest.java
+++ b/cascading-core/src/test/java/cascading/tuple/coerce/ShortObjectCoerceTest.java
@@ -1,0 +1,36 @@
+package cascading.tuple.coerce;
+
+import cascading.CascadingTestCase;
+import cascading.tuple.coerce.Coercions.Coerce;
+
+public class ShortObjectCoerceTest extends CascadingTestCase 
+{
+
+  private final Coerce<Short> coercion = Coercions.SHORT_OBJECT;
+
+  public void testCoerceShort() 
+  {
+    assertEquals(new Short((short) 1), coercion.coerce(new Short((short) 1)));
+  }
+
+  public void testCoerceNumber() 
+  {
+    assertEquals(new Short((short) 1), coercion.coerce(new Integer(1)));
+  }
+
+  public void testCoerceString() 
+  {
+    assertEquals(new Short((short) 1), coercion.coerce("1"));
+  }
+
+  public void testCoerceNull() 
+  {
+    assertEquals(null, coercion.coerce(null));
+  }
+
+  public void testCoerceEmptyString() 
+  {
+    assertEquals(null, coercion.coerce(""));
+  }
+
+}


### PR DESCRIPTION
I made this change when I had an output object that had Doubles, Longs, Shorts and Integer objects with values not set. For all types other than Short the output from Cascading was empty (which is what I want), but for Shorts it was zero. I had a look at all the Coercion types for Number objects and noticed ShortObjectCoerce was the only one that output a zero in this case - all the others output null. So I have changed ShortObjectCoerce to output null too. There weren't tests for the Coercion classes so I added one for ShortObjectCoerce to test my change and then added one for IntegerObjectCoerce for comparison.
