### PR TITLE
add reducer estimater based on input size

### DIFF
--- a/cascading-hadoop/src/main/java/cascading/flow/hadoop/HadoopFlow.java
+++ b/cascading-hadoop/src/main/java/cascading/flow/hadoop/HadoopFlow.java
@@ -28,7 +28,9 @@ import cascading.flow.Flow;
 import cascading.flow.FlowDef;
 import cascading.flow.FlowException;
 import cascading.flow.FlowProcess;
+import cascading.flow.FlowSkipStrategy;
 import cascading.flow.FlowStep;
+import cascading.flow.FlowStepStrategy;
 import cascading.flow.hadoop.util.HadoopUtil;
 import cascading.flow.planner.BaseFlowStep;
 import cascading.flow.planner.PlatformInfo;
@@ -280,4 +282,10 @@ public class HadoopFlow extends BaseFlow<JobConf>
     {
     return stepsAreLocal() ? 1 : getMaxConcurrentSteps( getConfig() );
     }
+  
+    @Override
+  public FlowStepStrategy<JobConf> getFlowStepStrategy() 
+	{
+	return new ReducerEstimaterStrategy();
+	}
   }

--- a/cascading-hadoop/src/main/java/cascading/flow/hadoop/HadoopFlowStep.java
+++ b/cascading-hadoop/src/main/java/cascading/flow/hadoop/HadoopFlowStep.java
@@ -37,7 +37,6 @@ import cascading.flow.planner.FlowStepJob;
 import cascading.flow.planner.Scope;
 import cascading.property.ConfigDef;
 import cascading.tap.Tap;
-import cascading.tap.hadoop.ReducerEstimater;
 import cascading.tap.hadoop.io.MultiInputFormat;
 import cascading.tap.hadoop.util.Hadoop18TapUtil;
 import cascading.tap.hadoop.util.TempHfs;
@@ -112,28 +111,6 @@ public class HadoopFlowStep extends BaseFlowStep<JobConf>
         conf.setNumReduceTasks( getSink().getScheme().getNumSinkParts() );
       else
         conf.setNumMapTasks( getSink().getScheme().getNumSinkParts() );
-      }else{
-    	if (getGroup()!=null){
-          Set<Tap> taps=getSources();
-    	  boolean allEstimatable=true;
-          for (Tap tap:taps){
-            if (!(tap instanceof ReducerEstimater)){
-                   allEstimatable=false;
-            }
-          }
-          if (allEstimatable){
-           int reducerNum=0;
-           for (Tap tap:taps){
-             try {
-                     reducerNum+=((ReducerEstimater)tap).getReducerNum(conf);
-             } catch (IOException e) {
-                     e.printStackTrace();
-                     throw new RuntimeException("IOException happens when estimating reducer from tap:"+tap.getIdentifier());
-             }
-           }
-           conf.setNumReduceTasks(reducerNum);
-         }
-        }
       }
 
     conf.setOutputKeyComparatorClass( TupleComparator.class );

--- a/cascading-hadoop/src/main/java/cascading/flow/hadoop/HadoopFlowStep.java
+++ b/cascading-hadoop/src/main/java/cascading/flow/hadoop/HadoopFlowStep.java
@@ -37,6 +37,7 @@ import cascading.flow.planner.FlowStepJob;
 import cascading.flow.planner.Scope;
 import cascading.property.ConfigDef;
 import cascading.tap.Tap;
+import cascading.tap.hadoop.ReducerEstimater;
 import cascading.tap.hadoop.io.MultiInputFormat;
 import cascading.tap.hadoop.util.Hadoop18TapUtil;
 import cascading.tap.hadoop.util.TempHfs;
@@ -111,6 +112,28 @@ public class HadoopFlowStep extends BaseFlowStep<JobConf>
         conf.setNumReduceTasks( getSink().getScheme().getNumSinkParts() );
       else
         conf.setNumMapTasks( getSink().getScheme().getNumSinkParts() );
+      }else{
+    	if (getGroup()!=null){
+          Set<Tap> taps=getSources();
+    	  boolean allEstimatable=true;
+          for (Tap tap:taps){
+            if (!(tap instanceof ReducerEstimater)){
+                   allEstimatable=false;
+            }
+          }
+          if (allEstimatable){
+           int reducerNum=0;
+           for (Tap tap:taps){
+             try {
+                     reducerNum+=((ReducerEstimater)tap).getReducerNum(conf);
+             } catch (IOException e) {
+                     e.printStackTrace();
+                     throw new RuntimeException("IOException happens when estimating reducer from tap:"+tap.getIdentifier());
+             }
+           }
+           conf.setNumReduceTasks(reducerNum);
+         }
+        }
       }
 
     conf.setOutputKeyComparatorClass( TupleComparator.class );

--- a/cascading-hadoop/src/main/java/cascading/flow/hadoop/ReducerEstimaterStrategy.java
+++ b/cascading-hadoop/src/main/java/cascading/flow/hadoop/ReducerEstimaterStrategy.java
@@ -1,0 +1,44 @@
+package cascading.flow.hadoop;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.hadoop.mapred.JobConf;
+
+import cascading.flow.Flow;
+import cascading.flow.FlowStep;
+import cascading.flow.FlowStepStrategy;
+import cascading.tap.Tap;
+import cascading.tap.hadoop.ReducerEstimater;
+
+public class ReducerEstimaterStrategy implements FlowStepStrategy<JobConf> {
+
+	@Override
+	public void apply(Flow<JobConf> flow,
+			List<FlowStep<JobConf>> predecessorSteps, FlowStep<JobConf> flowStep) {
+		Collection<Tap> taps = flow.getSourcesCollection();
+		JobConf conf = flowStep.getConfig();
+		boolean allEstimatable = true;
+		for (Tap tap : taps) {
+			if (!(tap instanceof ReducerEstimater)) {
+				allEstimatable = false;
+			}
+		}
+		if (allEstimatable) {
+			int reducerNum = 0;
+			for (Tap tap : taps) {
+				try {
+					reducerNum += ((ReducerEstimater) tap).getReducerNum(conf);
+				} catch (IOException e) {
+					e.printStackTrace();
+					throw new RuntimeException(
+							"IOException happens when estimating reducer from tap:"
+									+ tap.getIdentifier());
+				}
+			}
+			conf.setNumReduceTasks(reducerNum);
+		}
+	}
+
+}

--- a/cascading-hadoop/src/main/java/cascading/tap/hadoop/GlobHfs.java
+++ b/cascading-hadoop/src/main/java/cascading/tap/hadoop/GlobHfs.java
@@ -29,6 +29,8 @@ import cascading.flow.FlowProcess;
 import cascading.scheme.Scheme;
 import cascading.tap.MultiSourceTap;
 import cascading.tap.TapException;
+import cascading.tap.hadoop.util.ReducerEstimaterUtil;
+
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -55,7 +57,7 @@ import org.apache.hadoop.mapred.RecordReader;
  * @see cascading.tap.MultiSourceTap
  * @see FileSystem
  */
-public class GlobHfs extends MultiSourceTap<Hfs, JobConf, RecordReader>
+public class GlobHfs extends MultiSourceTap<Hfs, JobConf, RecordReader> implements ReducerEstimater
   {
   /** Field pathPattern */
   private final String pathPattern;
@@ -190,5 +192,15 @@ public class GlobHfs extends MultiSourceTap<Hfs, JobConf, RecordReader>
   public String toString()
     {
     return "GlobHfs[" + pathPattern + ']';
+    }
+  
+   @Override
+   public int getReducerNum(JobConf conf) throws IOException{
+     Hfs[] taps=getTaps();
+     List<Path> paths=new ArrayList<Path>();
+     for (Hfs tap: taps){
+             paths.add(tap.getPath());
+     }
+     return ReducerEstimaterUtil.estimateFromPath(paths, conf);
     }
   }

--- a/cascading-hadoop/src/main/java/cascading/tap/hadoop/Hfs.java
+++ b/cascading-hadoop/src/main/java/cascading/tap/hadoop/Hfs.java
@@ -24,6 +24,8 @@ import java.beans.ConstructorProperties;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import cascading.flow.FlowProcess;
@@ -35,6 +37,7 @@ import cascading.tap.TapException;
 import cascading.tap.hadoop.io.CombineFileRecordReaderWrapper;
 import cascading.tap.hadoop.io.HadoopTupleEntrySchemeCollector;
 import cascading.tap.hadoop.io.HadoopTupleEntrySchemeIterator;
+import cascading.tap.hadoop.util.ReducerEstimaterUtil;
 import cascading.tap.type.FileType;
 import cascading.tuple.Fields;
 import cascading.tuple.TupleEntryCollector;
@@ -102,7 +105,7 @@ import org.slf4j.LoggerFactory;
  * This is enabled by calling {@link HfsProps#setUseCombinedInput(boolean)} to {@code true}. By default, merging
  * or combining splits into large ones is disabled.
  */
-public class Hfs extends Tap<JobConf, RecordReader, OutputCollector> implements FileType<JobConf>
+public class Hfs extends Tap<JobConf, RecordReader, OutputCollector> implements FileType<JobConf>, ReducerEstimater
   {
   /** Field LOG */
   private static final Logger LOG = LoggerFactory.getLogger( Hfs.class );
@@ -652,6 +655,14 @@ public class Hfs extends Tap<JobConf, RecordReader, OutputCollector> implements 
 
     statuses = getFileSystem( conf ).listStatus( getPath() );
     }
+  
+   @Override
+   public int getReducerNum(JobConf conf) throws IOException {
+      Path path=getPath();
+      List<Path> paths=new ArrayList<Path>();
+      paths.add(path);
+      return ReducerEstimaterUtil.estimateFromPath(paths, conf);
+   }
 
   /** Combined input format that uses the underlying individual input format to combine multiple files into a single split. */
   static class CombinedInputFormat extends CombineFileInputFormat implements Configurable

--- a/cascading-hadoop/src/main/java/cascading/tap/hadoop/ReducerEstimater.java
+++ b/cascading-hadoop/src/main/java/cascading/tap/hadoop/ReducerEstimater.java
@@ -1,0 +1,10 @@
+package cascading.tap.hadoop;
+
+import java.io.IOException;
+
+import org.apache.hadoop.mapred.JobConf;
+
+public interface ReducerEstimater {
+
+        public int getReducerNum(JobConf conf) throws IOException;
+}

--- a/cascading-hadoop/src/main/java/cascading/tap/hadoop/util/ReducerEstimaterUtil.java
+++ b/cascading-hadoop/src/main/java/cascading/tap/hadoop/util/ReducerEstimaterUtil.java
@@ -1,0 +1,56 @@
+package cascading.tap.hadoop.util;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.JobConf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ReducerEstimaterUtil {
+
+	private static final Logger LOG = LoggerFactory
+			.getLogger(ReducerEstimaterUtil.class);
+
+	private static final String BYTES_PER_REDUCER_PARAM = "cascading.exec.reducers.bytes.per.reducer";
+	private static final String MAX_REDUCER_COUNT_PARAM = "cascading.exec.reducers.max";
+
+	private static final long DEFAULT_BYTES_PER_REDUCER = 1000 * 1000 * 1000;
+	private static final int DEFAULT_MAX_REDUCER_COUNT_PARAM = 999;
+
+	public static int estimateFromPath(List<Path> paths, JobConf conf)
+			throws IOException {
+		FileSystem fs = FileSystem.get(conf);
+		long bytesPerReducer = conf.getLong(BYTES_PER_REDUCER_PARAM,
+				DEFAULT_BYTES_PER_REDUCER);
+		int maxReducers = conf.getInt(MAX_REDUCER_COUNT_PARAM,
+				DEFAULT_MAX_REDUCER_COUNT_PARAM);
+
+		long totalInputFileSize = getTotalInputFileSize(paths, fs);
+
+		LOG.info("BytesPerReducer=" + bytesPerReducer + " maxReducers="
+				+ maxReducers + " totalInputFileSize=" + totalInputFileSize);
+
+		int reducers = (int) Math.ceil((double) totalInputFileSize
+				/ bytesPerReducer);
+		reducers = Math.max(1, reducers);
+		reducers = Math.min(maxReducers, reducers);
+
+		return reducers;
+	}
+
+	private static long getTotalInputFileSize(List<Path> paths, FileSystem fs)
+			throws IOException {
+		long totalInputFileSize = 0;
+		for (Path path : paths) {
+			FileStatus[] statuses = fs.listStatus(path);
+			for (FileStatus status : statuses) {
+				totalInputFileSize += status.getLen();
+			}
+		}
+		return totalInputFileSize;
+	}
+}

--- a/cascading-hadoop/src/main/java/cascading/tap/hadoop/util/ReducerEstimaterUtil.java
+++ b/cascading-hadoop/src/main/java/cascading/tap/hadoop/util/ReducerEstimaterUtil.java
@@ -10,6 +10,12 @@ import org.apache.hadoop.mapred.JobConf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
+/**
+ * 
+ * This piece of code is borrowed from pig (under Apache v2 license) with some customized modification
+ * 
+ */
 public class ReducerEstimaterUtil {
 
 	private static final Logger LOG = LoggerFactory


### PR DESCRIPTION
This patch is for estimating the reducer number based on the input size. This idear is borrowed from pig and hive which also do the similar thing.  The default setting is allocate 1 reducer for 1gb input data. User can change it by setting parameter "cascading.exec.reducers.bytes.per.reducer" 

BTW, is there any contribution guideline document for cascading ? Because my code style may be not compatible with the official code base. 
