### PR TITLE
RegexSplitter doesn't work when Fields are declared

### DIFF
--- a/cascading-core/src/main/java/cascading/operation/regex/RegexSplitter.java
+++ b/cascading-core/src/main/java/cascading/operation/regex/RegexSplitter.java
@@ -44,8 +44,7 @@ public class RegexSplitter extends RegexOperation<Pair<Pattern, Tuple>> implemen
   @ConstructorProperties({"patternString"})
   public RegexSplitter( String patternString )
     {
-    super( 1, patternString );
-    length = fieldDeclaration.isUnknown() ? -1 : fieldDeclaration.size();
+    this( Fields.UNKNOWN, patternString );
     }
 
   /**
@@ -56,8 +55,7 @@ public class RegexSplitter extends RegexOperation<Pair<Pattern, Tuple>> implemen
   @ConstructorProperties({"fieldDeclaration"})
   public RegexSplitter( Fields fieldDeclaration )
     {
-    super( 1, fieldDeclaration, "\t" );
-    length = fieldDeclaration.isUnknown() ? -1 : fieldDeclaration.size();
+    this( fieldDeclaration, "\t" );
     }
 
   /**
@@ -91,9 +89,11 @@ public class RegexSplitter extends RegexOperation<Pair<Pattern, Tuple>> implemen
 
     output.clear();
 
-    String[] split = functionCall.getContext().getLhs().split( value, length );
+    String[] split = functionCall.getContext().getLhs().split( value, length + 1 );
 
-    for( int i = 0; i < split.length; i++ )
+    int size = length == -1 ? split.length : length;
+
+    for( int i = 0; i < size; i++ )
       output.add( split[ i ] );
 
     functionCall.getOutputCollector().add( output );

--- a/cascading-core/src/test/java/cascading/operation/regex/RegexesTest.java
+++ b/cascading-core/src/test/java/cascading/operation/regex/RegexesTest.java
@@ -54,6 +54,23 @@ public class RegexesTest extends CascadingTestCase
     assertEquals( "not equal: tuple.get(0)", "foo", tuple.getObject( 0 ) );
     assertEquals( "not equal: tuple.get(1)", "bar", tuple.getObject( 1 ) );
     }
+  
+  public void testSplitterDeclared() throws IOException
+  {
+  RegexSplitter splitter = new RegexSplitter( new Fields("field"), "\t" );
+  Tuple arguments = new Tuple( "foo\tbar" );
+  Fields resultFields = Fields.UNKNOWN;
+
+  TupleListCollector collector = invokeFunction( splitter, arguments, resultFields );
+
+  assertEquals( "wrong size", 1, collector.size() );
+
+  Iterator<Tuple> iterator = collector.iterator();
+
+  Tuple tuple = iterator.next();
+
+  assertEquals( "not equal: tuple.get(0)", "foo", tuple.getObject( 0 ) );
+  }
 
   public void testSplitterGenerator() throws IOException
     {


### PR DESCRIPTION
The documentation for RegexSplitter on http://docs.cascading.org/cascading/1.2/userguide/html/ch07s06.html says that "If a known number of values will emerge from this function, it can declare field names. In this case, if the splitter encounters more split values than field names, the remaining values will be discarded".
But that's not what actually happens.

Let's say I have the following input value, AAAA:BBBB, and I want to split on the colon and keep only the first part, so I'd do something like this, new RegexSplitter( new Fields("A"), ":" ). But what I get as result in the A Field is the whole string, AAAA:BBBB (whereas the expected result was just AAAA).
I fixed this issue by taking into account the number of fields passed in the constructor and added one more unit test.
