### PR TITLE
LocalFlowProcess#getConfigCopy() and LocalFlowProcess#copyConfig(Properties) return an empty Properties

### DIFF
--- a/cascading-local/src/main/java/cascading/flow/local/LocalFlowProcess.java
+++ b/cascading-local/src/main/java/cascading/flow/local/LocalFlowProcess.java
@@ -180,13 +180,17 @@ public class LocalFlowProcess extends FlowProcess<Properties>
   @Override
   public Properties getConfigCopy()
     {
-    return new Properties( config );
+    Properties configCopy = new Properties( config );
+    configCopy.putAll( config );
+    return configCopy ;
     }
 
   @Override
   public Properties copyConfig( Properties config )
     {
-    return new Properties( config );
+    Properties configCopy = new Properties( config );
+    configCopy.putAll( config );
+    return configCopy ;
     }
 
   @Override


### PR DESCRIPTION
Greetings,

please consider the pull of this changes.

Updated `LocalFlowProcess#getConfigCopy()` and `LocalFlowProcess#copyConfig(Properties)` so they return a copy of the Properties (was returning an empty Properties).
With this modification, the semantic is now equal to HadoopFlowProcess when copying the configuration.

Recently I have started to test Cascading in local and cluster mode and I have been trying to launch flows conveying the configuration files in the .jar (core-site.xml, mapred-site.xml, hbase-site.xml, etc...) and not conveying the configuration files -just the configuration in `new LocalFlowConnector(properties)`-.
- In local mode:

I have found that in some parts of a custo Tap I have to get the configuration (generic parameter=Properties) so I end calling:

```
LocalFlowProcess#getConfigCopy()
```

that returns

```
new Properties( config );
```

if I am not wrong, this last sentence does not return a copy of the config properties, but only one with the set defaults (but in practice, empty). Taken from JDK source:

```
/**
 * Creates an empty property list with the specified defaults.
 *
 * @param defaults the defaults.
 */
public Properties(Properties defaults) {
    this.defaults = defaults;
}
```

So `LocalFlowProcess#getConfigCopy()` and `LocalFlowProcess#copyConfig()` should be something like:

```
Properties copyConfig = new Properties(config) ;
copyConfig.putAll(config) ;
return copyConfig ;
```
- In Hadoop mode:

In Hadoop mode, the implementation of `HadoopFlowProcess#getConfigCopy()` is:

```
return new JobConf( jobConf );
```

but in this case the semantic is different from the local one: it creates a copy.

I have tested the changes and seems to work as I expected. I could be wrong anyway...
