### PR TITLE
returning empty recordReader in case of invalidinputsplit

### DIFF
--- a/src/hadoop/cascading/tap/hadoop/MultiInputFormat.java
+++ b/src/hadoop/cascading/tap/hadoop/MultiInputFormat.java
@@ -240,6 +240,38 @@ public class MultiInputFormat implements InputFormat
       }
     catch( Exception exception )
       {
+      if(job.getBoolean("skipinvalidinput", false)){
+       	return new RecordReader(){
+    	@Override
+    	public boolean next(Object key, Object value)
+    			throws IOException {
+    	  return false;
+    	}
+
+    	@Override
+    	public Object createKey() {
+    	  return null;
+    	}
+
+    	@Override
+    	public Object createValue() {
+    	  return null;
+    	}
+
+    	@Override
+    	public long getPos() throws IOException {
+    	  return 0;
+    	}
+
+    	@Override
+    	public void close() throws IOException {
+    	}
+    	@Override
+    	public float getProgress() throws IOException {
+    	  return 0;
+    	}
+      };
+      }
       if( exception instanceof RuntimeException )
         throw (RuntimeException) exception;
       else


### PR DESCRIPTION
returning empty recordReader in case of invalidinputsplit when
skipinvalidinput = true else re rethrowing the exception as per existing
logic.
Incase of single invalid input file whole job used to fail. This will help to ignore any invalid file and still continue to process the rest of the files.
