### PR TITLE
Wip 2.6 tracing

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,8 @@ Cascading Change Log
 
 2.6.0 [unreleased]
 
+  Added ability to customize trace data captured for debugging purposes.
+
   Added CONTRIBUTING.md.
 
   Updated c.t.h.DistCacheTap to support simple file globing as provided by c.t.h.Hfs.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,8 @@ Cascading Change Log
 
 2.6.0 [unreleased]
 
+  Added CONTRIBUTING.md.
+
   Updated c.t.h.DistCacheTap to support simple file globing as provided by c.t.h.Hfs.
 
   Fixed issue where c.p.a.UniqueBy was not honoring the c.t.Hasher interface.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,110 @@
+# How To Contribute
+
+There is a rapidly growing list of projects and companies relying on Cascading. Keeping Cascading exceptionally 
+dependable and stable is paramount.    
+
+But for Cascading to continue to evolve and meet expectations of its users, enhancements and fixes from third-parties 
+are essential. Oftentimes meeting these goals is not frictionless.
+
+To mitigate this, we have set up guidelines and expectations for contributions, along with added clarity of our 
+commitment.
+
+At the end of the day, the Cascading team is responsible for the quality of Cascading core, this entails 
+supporting all code in the core, which is a large time and financial commitment. 
+
+To keep this manageable, we prefer to open up new APIs for extension over adding enhancements directly to Cascading. As
+Cascading is a framework, this philosophy fits nicely compared to other projects. 
+
+In lieu of that, for any major or deep enhancements we expect to guide the design from inception in order to retain 
+conceptual integrity throughout Cascading and across each release. 
+
+This will minimize our long term burden, and time spent over the back and forth discussions over any premature patch. 
+It will also ensure future compatibility with upcoming versions and proposed changes. 
+
+So initiating a discussion on the mail list before development, and continuing against a well tested GitHub pull 
+request are reasonable expectations.
+
+## Bugs and Minor Changes
+
+If simply reporting a bug, look for a comparable test in the `cascading-platform` sub-project, reproduce your issue as 
+a failing test added to one of the existing suites.
+
+If suggesting a trivial change (fixing a typo, etc), please simply bring attention via the mail list. We are happy to
+make the changes.
+
+## Creating a Cascading Extension
+
+To be included to our growing list of [Cascading extensions](http://www.cascading.org/extensions/), simply 
+bring your proposal up on the mail-list to see if there is an opportunity for collaboration with other community
+members, or inclusion into any existing project.
+
+Also call out any changes to the Cascading core API that would be necessary to support the extension.
+
+We are happy to quickly add new well thought out API calls in minor (or maintenance releases if trivial). Changes to 
+existing APIs must be made against major releases.
+
+The [Conjars](http://conjars.org) Maven repository is available to ease the distribution of Cascading extensions. 
+Creating an account is simple, uploads are possible via SSH or HTTP. 
+
+Pushing artifacts to Conjars is not an expectation, but do consider making any extensions available via Maven to 
+simply inclusion by end-users.
+
+When a new extension is available, please notify the mail list, or email support@cascading.org to be included
+on the extensions page.
+
+## Enhancing Cascading Core
+
+If the proposed enhancement will not fit neatly as a simple extension to Cascading (see above), please follow these
+guidelines.
+
+### Getting Started
+
+* Make sure you have joined the [Cascading User mailing list](http://cascading.org/support/)
+* Make sure you have a [GitHub account](https://github.com/signup/free)
+* **Email the list with your feature or bug fix proposal**
+  * Clearly describe the issue
+  * Make sure you note the earliest version that you know has the issue
+* Fork the repository on GitHub from [Cascading/cascading](https://github.com/Cascading/cascading)
+  * If resolving an issue with a current pre-release WIP, fork from [cwensel/cascading](https://github.com/cwensel/cascading)
+* Create a topic branch from where you want to base your work
+  * This is usually the release branch (2.5) or release tag (2.5.5). Or wip releases (wip-2.6) 
+  * Only target release branches if you are certain your fix must be on that branch
+  * To quickly create a topic branch based on a release; `git checkout -b wip-2.5-topic origin/2.5`, 
+    where 'topic' is describes your change
+* Make commits of logical units, the fewer the better
+* Check for unnecessary whitespace with `git diff --check` before committing
+
+### Testing Changes
+
+Cascading required Gradle to build, see the README for the latest supported version.
+
+Calling:
+
+    > gradle clean cascading-local:test cascading-local:platformTest 
+
+will run all tests for the Cascading local mode platform. This works for other supported platforms.
+
+### Submitting Changes
+
+* Sign the [Concurrent Contributor License Agreement](http://files.concurrentinc.com/agreements/Concurrent_Contributor_Agreement.doc)
+  and email as a PDF to support@cascading.org
+* Push your changes to a topic branch in your fork of the repository
+* Submit a pull request to the repository in the Cascading organization
+* Follow up on the original email thread with a link to the pull request
+* After feedback has been given we expect responses within two weeks, after which we may close the pull request 
+  if it isn't showing any activity
+
+### Next Steps
+
+The Cascading team will review any requests and provide feedback. Hopefully this will be minimal if we had a prior
+discussion regarding the enhancements. 
+
+Regardless of the process, we reserve the right to decide when and if an enhancement will be included in any given 
+release. We prefer to push large changes into major or minor releases, and small changes in minor or maintenance 
+releases. This decision is based on the level and quality of changes that need to be acknowledge and absorbed, if at 
+all, by the end-users.
+
+We will not merge a pull request directly from GitHub. We find the resulting git history complicated and unnecessary. 
+
+Subsequently most commits are rebased and cleaned up on our side, and all are committed with full attribution of the 
+original author.

--- a/cascading-core/src/main/java/cascading/cascade/CascadeProps.java
+++ b/cascading-core/src/main/java/cascading/cascade/CascadeProps.java
@@ -51,6 +51,11 @@ public class CascadeProps extends Props
     properties.put( MAX_CONCURRENT_FLOWS, Integer.toString( numConcurrentFlows ) );
     }
 
+  /**
+   * Creates a new CascadeProps instance.
+   *
+   * @return CascadeProps instance
+   */
   public static CascadeProps cascadeProps()
     {
     return new CascadeProps();
@@ -65,6 +70,16 @@ public class CascadeProps extends Props
     return maxConcurrentFlows;
     }
 
+  /**
+   * Method setMaxConcurrentFlows sets the maximum number of Flows that a Cascade can run concurrently.
+   * <p/>
+   * A value of one (1) will run one Flow at a time. A value of zero (0), the default, disables the restriction.
+   * <p/>
+   * By default a Cascade will attempt to run all give Flow instances at the same time, if eligible. But there are
+   * occasions where limiting the number for flows helps manages resources.
+   *
+   * @param maxConcurrentFlows of type int
+   */
   public CascadeProps setMaxConcurrentFlows( int maxConcurrentFlows )
     {
     this.maxConcurrentFlows = maxConcurrentFlows;

--- a/cascading-core/src/main/java/cascading/flow/FlowConnectorProps.java
+++ b/cascading-core/src/main/java/cascading/flow/FlowConnectorProps.java
@@ -123,6 +123,16 @@ public class FlowConnectorProps extends Props
       properties.put( CHECKPOINT_TAP_DECORATOR_CLASS, checkpointTapDecoratorClassName );
     }
 
+  /**
+   * Creates a new FlowConnectorProps instance.
+   *
+   * @return FlowConnectorProps instance
+   */
+  public static FlowConnectorProps flowConnectorProps()
+    {
+    return new FlowConnectorProps();
+    }
+
   public FlowConnectorProps()
     {
     }

--- a/cascading-core/src/main/java/cascading/flow/FlowProps.java
+++ b/cascading-core/src/main/java/cascading/flow/FlowProps.java
@@ -116,6 +116,15 @@ public class FlowProps extends Props
     properties.put( STOP_JOBS_ON_EXIT, Boolean.toString( stopJobsOnExit ) );
     }
 
+  /**
+   * Creates a new FlowProps instance.
+   *
+   * @return FlowProps instance
+   */
+  public static FlowProps flowProps()
+    {
+    return new FlowProps();
+    }
 
   public FlowProps()
     {
@@ -126,6 +135,18 @@ public class FlowProps extends Props
     return defaultTupleElementComparator;
     }
 
+  /**
+   * Sets a default {@link java.util.Comparator} to be used if no Comparator can be found for the class via the
+   * {@link cascading.tuple.Comparison} interface.
+   * <p/>
+   * In the case of Hadoop, if the Comparator instance also implements {@link org.apache.hadoop.conf.Configurable}, the
+   * {@link org.apache.hadoop.conf.Configurable#setConf(org.apache.hadoop.conf.Configuration)}
+   * will be called.
+   * <p/>
+   * In local mode, only the default constructor will be called for the comparator.
+   *
+   * @param defaultTupleElementComparator
+   */
   public FlowProps setDefaultTupleElementComparator( String defaultTupleElementComparator )
     {
     this.defaultTupleElementComparator = defaultTupleElementComparator;
@@ -138,6 +159,12 @@ public class FlowProps extends Props
     return preserveTemporaryFiles;
     }
 
+  /**
+   * Property preserveTemporaryFiles forces the Flow instance to keep any temporary intermediate data sets. Useful
+   * for debugging. Defaults to {@code false}.
+   *
+   * @param preserveTemporaryFiles of type boolean
+   */
   public FlowProps setPreserveTemporaryFiles( boolean preserveTemporaryFiles )
     {
     this.preserveTemporaryFiles = preserveTemporaryFiles;
@@ -150,6 +177,12 @@ public class FlowProps extends Props
     return jobPollingInterval;
     }
 
+  /**
+   * Property jobPollingInterval will set the time to wait between polling the remote server for the status of a job.
+   * The default value is 5000 msec (5 seconds).
+   *
+   * @param jobPollingInterval of type long
+   */
   public FlowProps setJobPollingInterval( int jobPollingInterval )
     {
     this.jobPollingInterval = jobPollingInterval;
@@ -162,6 +195,14 @@ public class FlowProps extends Props
     return maxConcurrentSteps;
     }
 
+  /**
+   * Method setMaxConcurrentSteps sets the maximum number of steps that a Flow can run concurrently.
+   * <p/>
+   * By default a Flow will attempt to run all give steps at the same time. But there are occasions
+   * where limiting the number of steps helps manages resources.
+   *
+   * @param maxConcurrentSteps of type int
+   */
   public FlowProps setMaxConcurrentSteps( int maxConcurrentSteps )
     {
     this.maxConcurrentSteps = maxConcurrentSteps;
@@ -174,6 +215,12 @@ public class FlowProps extends Props
     return stopJobsOnExit;
     }
 
+  /**
+   * Property stopJobsOnExit will tell the Flow to add a JVM shutdown hook that will kill all running processes if the
+   * underlying computing system supports it. Defaults to {@code true}.
+   *
+   * @param stopJobsOnExit of type boolean
+   */
   public FlowProps setStopJobsOnExit( boolean stopJobsOnExit )
     {
     this.stopJobsOnExit = stopJobsOnExit;

--- a/cascading-core/src/main/java/cascading/flow/planner/ElementGraphException.java
+++ b/cascading-core/src/main/java/cascading/flow/planner/ElementGraphException.java
@@ -24,7 +24,7 @@ import cascading.flow.FlowElement;
 import cascading.flow.FlowException;
 import cascading.pipe.Pipe;
 import cascading.tap.Tap;
-import cascading.util.Util;
+import cascading.util.TraceUtil;
 
 /**
  * Class ElementGraphException is thrown during rendering of a pipe assembly to
@@ -42,12 +42,12 @@ public class ElementGraphException extends FlowException
 
   public ElementGraphException( Pipe pipe, String message )
     {
-    this( (FlowElement) pipe, Util.formatTrace( pipe, message ) );
+    this( (FlowElement) pipe, TraceUtil.formatTrace( pipe, message ) );
     }
 
   public ElementGraphException( Tap tap, String message )
     {
-    this( (FlowElement) tap, Util.formatTrace( tap, message ) );
+    this( (FlowElement) tap, TraceUtil.formatTrace( tap, message ) );
     }
 
   /**

--- a/cascading-core/src/main/java/cascading/flow/planner/PlannerException.java
+++ b/cascading-core/src/main/java/cascading/flow/planner/PlannerException.java
@@ -23,7 +23,7 @@ package cascading.flow.planner;
 import cascading.flow.FlowElement;
 import cascading.flow.FlowException;
 import cascading.pipe.Pipe;
-import cascading.util.Util;
+import cascading.util.TraceUtil;
 import org.jgrapht.graph.SimpleDirectedGraph;
 
 /**
@@ -52,7 +52,7 @@ public class PlannerException extends FlowException
    */
   public PlannerException( Pipe pipe, String message )
     {
-    super( Util.formatTrace( pipe, message ) );
+    super( TraceUtil.formatTrace( pipe, message ) );
     }
 
   /**
@@ -64,7 +64,7 @@ public class PlannerException extends FlowException
    */
   public PlannerException( Pipe pipe, String message, Throwable throwable )
     {
-    super( Util.formatTrace( pipe, message ), throwable );
+    super( TraceUtil.formatTrace( pipe, message ), throwable );
     }
 
   /**
@@ -77,7 +77,7 @@ public class PlannerException extends FlowException
    */
   public PlannerException( Pipe pipe, String message, Throwable throwable, ElementGraph elementGraph )
     {
-    super( Util.formatTrace( pipe, message ), throwable );
+    super( TraceUtil.formatTrace( pipe, message ), throwable );
     this.elementGraph = elementGraph;
     }
 

--- a/cascading-core/src/main/java/cascading/management/annotation/Visibility.java
+++ b/cascading-core/src/main/java/cascading/management/annotation/Visibility.java
@@ -24,10 +24,26 @@ package cascading.management.annotation;
  * Visibility controls whether a certain {@link cascading.management.annotation.Property} is visible to a certain
  * audience.
  * <p/>
+ * <lu>
+ * <li>{@link #PRIVATE} - recommended that only a developer or team/project member have access to the value</li>
+ * <li>{@link #PROTECTED} - recommended for interested and authorized parties</li>
+ * <li>{@link #PUBLIC} - recommended for use as general purpose information</li>
+ * </lu>
+ * <p/>
+ * All properties in Cascading using the {@link cascading.management.annotation.Property} annotation are marked as
+ * {@link #PRIVATE}.
+ * <p/>
+ * Except for {@link cascading.tap.Tap#getIdentifier()} which defines the {@link cascading.management.annotation.Sanitizer}
+ * implementation {@link cascading.management.annotation.URISanitizer} which attempts to cleanse the URI identifier
+ * for each of the above visibilities.
+ * <p/>
  * It is up to the implementation of a {@link cascading.management.DocumentService} to interpret and use these
  * values.
  * <p/>
  * Cascading does not enforce any restrictions related to the values, they are considered informative.
+ * <p/>
+ * To prevent serialization of any value via the registered {@link cascading.management.DocumentService}, do not
+ * mark a field with the Property annotation, or configure the service appropriately.
  */
 public enum Visibility
   {

--- a/cascading-core/src/main/java/cascading/operation/BaseOperation.java
+++ b/cascading-core/src/main/java/cascading/operation/BaseOperation.java
@@ -29,7 +29,8 @@ import cascading.pipe.Every;
 import cascading.pipe.Pipe;
 import cascading.tuple.Fields;
 import cascading.tuple.Tuple;
-import cascading.util.Util;
+import cascading.util.TraceUtil;
+import cascading.util.Traceable;
 
 /**
  * Class BaseOperation is the base class of predicate types that are applied to {@link Tuple} streams via
@@ -40,17 +41,16 @@ import cascading.util.Util;
  * <p/>
  * By default, {@link #isSafe()} returns {@code true}.
  */
-public abstract class BaseOperation<Context> implements Serializable, Operation<Context>
+public abstract class BaseOperation<Context> implements Serializable, Operation<Context>, Traceable
   {
   /** Field fieldDeclaration */
   protected Fields fieldDeclaration;
   /** Field numArgs */
   protected int numArgs = ANY;
   /** Field trace */
-  protected String trace = Util.captureDebugTrace( getClass() );
+  protected String trace = TraceUtil.captureDebugTrace( this ); // see TraceUtil.setTrace() to override
 
   // initialize this operation based on its subclass
-
   {
   if( this instanceof Filter || this instanceof Assertion )
     fieldDeclaration = Fields.ALL;
@@ -155,11 +155,7 @@ public abstract class BaseOperation<Context> implements Serializable, Operation<
     return true;
     }
 
-  /**
-   * Method getTrace returns the trace of this BaseOperation object.
-   *
-   * @return the trace (type String) of this BaseOperation object.
-   */
+  @Override
   public String getTrace()
     {
     return trace;

--- a/cascading-core/src/main/java/cascading/operation/assertion/BaseAssertion.java
+++ b/cascading-core/src/main/java/cascading/operation/assertion/BaseAssertion.java
@@ -27,7 +27,7 @@ import cascading.operation.AssertionLevel;
 import cascading.operation.BaseOperation;
 import cascading.operation.PlannedOperation;
 import cascading.operation.PlannerLevel;
-import cascading.util.Util;
+import cascading.util.TraceUtil;
 
 /**
  * Class BaseAssertion is a convenience class for {@link cascading.operation.Assertion} implementations. Subclassing
@@ -46,19 +46,19 @@ public abstract class BaseAssertion<C> extends BaseOperation<C> implements Plann
     {
     }
 
-  @ConstructorProperties({"message"})
+  @ConstructorProperties( {"message"} )
   protected BaseAssertion( String message )
     {
     this.message = message;
     }
 
-  @ConstructorProperties({"numArgs"})
+  @ConstructorProperties( {"numArgs"} )
   protected BaseAssertion( int numArgs )
     {
     super( numArgs );
     }
 
-  @ConstructorProperties({"numArgs", "message"})
+  @ConstructorProperties( {"numArgs", "message"} )
   protected BaseAssertion( int numArgs, String message )
     {
     super( numArgs );
@@ -78,12 +78,12 @@ public abstract class BaseAssertion<C> extends BaseOperation<C> implements Plann
 
   protected void fail()
     {
-    throwFail( Util.formatTrace( this, getMessage() ) );
+    throwFail( TraceUtil.formatTrace( this, getMessage() ) );
     }
 
   protected void fail( Object... args )
     {
-    throwFail( Util.formatTrace( this, getMessage() ), args );
+    throwFail( TraceUtil.formatTrace( this, getMessage() ), args );
     }
 
   /**

--- a/cascading-core/src/main/java/cascading/pipe/OperatorException.java
+++ b/cascading-core/src/main/java/cascading/pipe/OperatorException.java
@@ -22,7 +22,7 @@ package cascading.pipe;
 
 import cascading.CascadingException;
 import cascading.tuple.Fields;
-import cascading.util.Util;
+import cascading.util.TraceUtil;
 
 /** Class OperatorException is thrown during field name resolution during planning */
 public class OperatorException extends CascadingException
@@ -52,7 +52,7 @@ public class OperatorException extends CascadingException
    */
   public OperatorException( Pipe pipe, String string )
     {
-    super( Util.formatTrace( pipe, string ) );
+    super( TraceUtil.formatTrace( pipe, string ) );
     }
 
   /**
@@ -64,7 +64,7 @@ public class OperatorException extends CascadingException
    */
   public OperatorException( Pipe pipe, String string, Throwable throwable )
     {
-    super( Util.formatTrace( pipe, string ), throwable );
+    super( TraceUtil.formatTrace( pipe, string ), throwable );
     }
 
   /** @see cascading.CascadingException#CascadingException(String) */
@@ -191,7 +191,7 @@ public class OperatorException extends CascadingException
     String message = "unable to resolve output selector: " + outputSelector.printVerbose() +
       ", with incoming: " + incomingFields.printVerbose() + " and declared: " + declaredFields.printVerbose();
 
-    return Util.formatTrace( pipe, message );
+    return TraceUtil.formatTrace( pipe, message );
     }
 
   private static String createMessage( Pipe pipe, Kind kind, Fields incomingFields, Fields argumentSelector )
@@ -199,7 +199,7 @@ public class OperatorException extends CascadingException
     String message = "unable to resolve " + kind + " selector: " + argumentSelector.printVerbose() +
       ", with incoming: " + incomingFields.printVerbose();
 
-    return Util.formatTrace( pipe, message );
+    return TraceUtil.formatTrace( pipe, message );
     }
 
   }

--- a/cascading-core/src/main/java/cascading/pipe/Pipe.java
+++ b/cascading-core/src/main/java/cascading/pipe/Pipe.java
@@ -30,6 +30,8 @@ import cascading.flow.FlowElement;
 import cascading.flow.planner.Scope;
 import cascading.property.ConfigDef;
 import cascading.tuple.Fields;
+import cascading.util.TraceUtil;
+import cascading.util.Traceable;
 import cascading.util.Util;
 
 import static java.util.Arrays.asList;
@@ -56,7 +58,7 @@ import static java.util.Arrays.asList;
  * @see HashJoin
  * @see SubAssembly
  */
-public class Pipe implements FlowElement, Serializable
+public class Pipe implements FlowElement, Serializable, Traceable
   {
   /** Field serialVersionUID */
   private static final long serialVersionUID = 1L;
@@ -74,7 +76,7 @@ public class Pipe implements FlowElement, Serializable
   /** Field id */
   private final String id = Util.createUniqueID(); // 3.0 planner relies on this being consistent
   /** Field trace */
-  private String trace = Util.captureDebugTrace( getClass() ); // see Util.setTrace() to override
+  private String trace = TraceUtil.captureDebugTrace( this ); // see TraceUtil.setTrace() to override
 
   public static synchronized String id( Pipe pipe )
     {
@@ -375,11 +377,7 @@ public class Pipe implements FlowElement, Serializable
     throw new IllegalStateException( "resolveIncomingOperationPassThroughFields should never be called" );
     }
 
-  /**
-   * Method getTrace returns a String that pinpoint where this instance was created for debugging.
-   *
-   * @return String
-   */
+  @Override
   public String getTrace()
     {
     return trace;

--- a/cascading-core/src/main/java/cascading/pipe/SubAssembly.java
+++ b/cascading-core/src/main/java/cascading/pipe/SubAssembly.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import cascading.util.TraceUtil;
 import cascading.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -172,7 +173,7 @@ public abstract class SubAssembly extends Pipe
   public String[] getTailNames()
     {
     if( tails == null )
-      throw new IllegalStateException( Util.formatRawTrace( this, "setTails must be called in the constructor" ) );
+      throw new IllegalStateException( TraceUtil.formatRawTrace( this, "setTails must be called in the constructor" ) );
 
     if( names != null )
       return names;
@@ -200,7 +201,7 @@ public abstract class SubAssembly extends Pipe
     // returns the semantically equivalent to Pipe#previous to simplify logic in the planner
     // SubAssemblies are really aliases for their tails
     if( tails == null )
-      throw new IllegalStateException( Util.formatRawTrace( this, "setTails must be called after the sub-assembly is assembled" ) );
+      throw new IllegalStateException( TraceUtil.formatRawTrace( this, "setTails must be called after the sub-assembly is assembled" ) );
 
     return Arrays.copyOf( tails, tails.length );
     }

--- a/cascading-core/src/main/java/cascading/property/AppProps.java
+++ b/cascading-core/src/main/java/cascading/property/AppProps.java
@@ -36,10 +36,12 @@ import static cascading.util.Util.join;
  * {@link cascading.flow.Flow} may or may not be required to have set. These properties are typically passed to a Flow
  * via a {@link cascading.flow.FlowConnector}.
  * <p/>
+ * New property settings that may be set in Cascading 2 are application name, version, and any tags.
+ * <p/>
+ * See {@link #addTag(String)} for examples of using tags to help manage an application.
+ * <p/>
  * In prior releases, the FlowConnector was responsible for setting the "application jar" class or path. Those
  * methods have been deprecated and moved to AppProps.
- * <p/>
- * New property settings that may be set in Cascading 2 are application name, version, and any tags.
  */
 public class AppProps extends Props
   {
@@ -66,6 +68,11 @@ public class AppProps extends Props
   protected String jarPath;
   protected Set<String> frameworks = new TreeSet<String>();
 
+  /**
+   * Creates a new AppProps instance.
+   *
+   * @return AppProps instance
+   */
   public static AppProps appProps()
     {
     return new AppProps();
@@ -262,6 +269,15 @@ public class AppProps extends Props
     this.version = version;
     }
 
+  /**
+   * Method setName sets the application name.
+   * <p/>
+   * By default the application name is derived from the jar name (values before the version in most Maven
+   * compatible jars).
+   *
+   * @param name type String
+   * @return this
+   */
   public AppProps setName( String name )
     {
     this.name = name;
@@ -269,6 +285,15 @@ public class AppProps extends Props
     return this;
     }
 
+  /**
+   * Method setVersion sets the application version.
+   * <p/>
+   * By default the application version is derived from the jar name (values after the name in most Maven
+   * compatible jars).
+   *
+   * @param version type String
+   * @return this
+   */
   public AppProps setVersion( String version )
     {
     this.version = version;
@@ -281,6 +306,25 @@ public class AppProps extends Props
     return join( tags, "," );
     }
 
+  /**
+   * Method addTag will associate a "tag" with this application. Applications can have an unlimited number of tags.
+   * <p/>
+   * Tags allow applications to be searched and organized by management tools.
+   * <p/>
+   * Tag values are opaque, but adopting a simple convention of 'category:value' allows for complex use cases.
+   * <p/>
+   * Some recommendations for categories are:
+   * <p/>
+   * <ul>
+   * <lli>cluster: - the cluster name the application is or should be run against. A name could be logical, like QA or PROD.</lli>
+   * <lli>project: - the project name, possibly a JIRA project name this application is managed under.</lli>
+   * <lli>org: - the group, team or organization that is responsible for the application.</lli>
+   * <lli>support: - the email address of the user who should be notified of failures or issues.</lli>
+   * </ul>
+   *
+   * @param tag type String
+   * @return this
+   */
   public AppProps addTag( String tag )
     {
     if( !Util.isEmpty( tag ) )
@@ -289,6 +333,25 @@ public class AppProps extends Props
     return this;
     }
 
+  /**
+   * Method addTags will associate the given "tags" with this application. Applications can have an unlimited number of tags.
+   * <p/>
+   * Tags allow applications to be searched and organized by management tools.
+   * <p/>
+   * Tag values are opaque, but adopting a simple convention of 'category:value' allows for complex use cases.
+   * <p/>
+   * Some recommendations for categories are:
+   * <p/>
+   * <ul>
+   * <lli>cluster: - the cluster name the application is or should be run against. A name could be logical, like QA or PROD.</lli>
+   * <lli>project: - the project name, possibly a JIRA project name this application is managed under.</lli>
+   * <lli>org: - the group, team or organization that is responsible for the application.</lli>
+   * <lli>support: - the email address of the user who should be notified of failures or issues.</lli>
+   * </ul>
+   *
+   * @param tags type String
+   * @return this
+   */
   public AppProps addTags( String... tags )
     {
     for( String tag : tags )
@@ -298,7 +361,7 @@ public class AppProps extends Props
     }
 
   /**
-   * Returns a list of frameworks used to build this App.
+   * Method getFrameworks returns a list of frameworks used to build this App.
    *
    * @return Registered frameworks
    */
@@ -308,7 +371,7 @@ public class AppProps extends Props
     }
 
   /**
-   * Adds a new framework name to the list of frameworks used.
+   * Method addFramework adds a new framework name to the list of frameworks used.
    * <p/>
    * Higher level tools should register themselves, and preferably with their version,
    * for example {@code foo-flow-builder:1.2.3}.
@@ -327,7 +390,7 @@ public class AppProps extends Props
     }
 
   /**
-   * Adds a new framework name and its version to the list of frameworks used.
+   * Method addFramework adds a new framework name and its version to the list of frameworks used.
    * <p/>
    * Higher level tools should register themselves, and preferably with their version,
    * for example {@code foo-flow-builder:1.2.3}.
@@ -347,7 +410,7 @@ public class AppProps extends Props
     }
 
   /**
-   * Adds new framework names to the list of frameworks used.
+   * Method addFrameworks adds new framework names to the list of frameworks used.
    * <p/>
    * Higher level tools should register themselves, and preferably with their version,
    * for example {@code foo-flow-builder:1.2.3}.

--- a/cascading-core/src/main/java/cascading/property/Props.java
+++ b/cascading-core/src/main/java/cascading/property/Props.java
@@ -28,6 +28,9 @@ import java.util.Properties;
  * <p/>
  * Use the sub-classes to either create a {@link Properties} instance with custom or default values to be passed
  * to any sub-system that requires a Map or Properties instance of properties and values.
+ * <p/>
+ * Note some Props sub-classes have static accessors. It is recommended the fluent instance methods be used instead
+ * of the static methods. All static accessors may be deprecated in future versions.
  */
 public abstract class Props
   {

--- a/cascading-core/src/main/java/cascading/scheme/Scheme.java
+++ b/cascading-core/src/main/java/cascading/scheme/Scheme.java
@@ -27,7 +27,8 @@ import cascading.flow.FlowProcess;
 import cascading.tap.Tap;
 import cascading.tuple.Fields;
 import cascading.tuple.Tuple;
-import cascading.util.Util;
+import cascading.util.TraceUtil;
+import cascading.util.Traceable;
 
 /**
  * A Scheme defines what is stored in a {@link Tap} instance by declaring the {@link Tuple}
@@ -58,7 +59,7 @@ import cascading.util.Util;
  * numSinkParts may be ignored entirely if the final job is Map only. To force the Flow to have a final Reduce,
  * add a {@link cascading.pipe.GroupBy} to the assembly before sinking.
  */
-public abstract class Scheme<Config, Input, Output, SourceContext, SinkContext> implements Serializable
+public abstract class Scheme<Config, Input, Output, SourceContext, SinkContext> implements Serializable, Traceable
   {
   /** Field sinkFields */
   Fields sinkFields = Fields.ALL;
@@ -67,7 +68,7 @@ public abstract class Scheme<Config, Input, Output, SourceContext, SinkContext> 
   /** Field numSinkParts */
   int numSinkParts;
   /** Field trace */
-  private String trace = Util.captureDebugTrace( getClass() ); // see Util.setTrace() to override
+  private String trace = TraceUtil.captureDebugTrace( this ); // see TraceUtil.setTrace() to override
 
   /** Constructor Scheme creates a new Scheme instance. */
   protected Scheme()
@@ -188,11 +189,7 @@ public abstract class Scheme<Config, Input, Output, SourceContext, SinkContext> 
     this.numSinkParts = numSinkParts;
     }
 
-  /**
-   * Method getTrace returns a String that pinpoint where this instance was created for debugging.
-   *
-   * @return String
-   */
+  @Override
   public String getTrace()
     {
     return trace;

--- a/cascading-core/src/main/java/cascading/tap/Tap.java
+++ b/cascading-core/src/main/java/cascading/tap/Tap.java
@@ -41,6 +41,8 @@ import cascading.tuple.FieldsResolverException;
 import cascading.tuple.Tuple;
 import cascading.tuple.TupleEntryCollector;
 import cascading.tuple.TupleEntryIterator;
+import cascading.util.TraceUtil;
+import cascading.util.Traceable;
 import cascading.util.Util;
 
 /**
@@ -65,7 +67,7 @@ import cascading.util.Util;
  * {@link cascading.cascade.Cascade}. In that case the {@link #getFullIdentifier(Object)} value is used and the Scheme
  * is ignored.
  */
-public abstract class Tap<Config, Input, Output> implements FlowElement, Serializable
+public abstract class Tap<Config, Input, Output> implements FlowElement, Serializable, Traceable
   {
   /** Field scheme */
   private Scheme<Config, Input, Output, ?, ?> scheme;
@@ -80,7 +82,7 @@ public abstract class Tap<Config, Input, Output> implements FlowElement, Seriali
   /** Field id */
   private final String id = Util.createUniqueID(); // 3.0 planner relies on this being consistent
   /** Field trace */
-  private String trace = Util.captureDebugTrace( getClass() ); // see Util.setTrace() to override
+  private String trace = TraceUtil.captureDebugTrace( this ); // see TraceUtil.setTrace() to override
 
   /**
    * Convenience function to make an array of Tap instances.
@@ -140,11 +142,7 @@ public abstract class Tap<Config, Input, Output> implements FlowElement, Seriali
     return scheme;
     }
 
-  /**
-   * Method getTrace return the trace of this object.
-   *
-   * @return String
-   */
+  @Override
   public String getTrace()
     {
     return trace;

--- a/cascading-core/src/main/java/cascading/tap/TapException.java
+++ b/cascading-core/src/main/java/cascading/tap/TapException.java
@@ -23,7 +23,7 @@ package cascading.tap;
 import cascading.CascadingException;
 import cascading.tuple.Fields;
 import cascading.tuple.Tuple;
-import cascading.util.Util;
+import cascading.util.TraceUtil;
 
 /**
  * Class TapException is thrown from {@link Tap} and {@link cascading.scheme.Scheme} subclasses.
@@ -120,6 +120,6 @@ public class TapException extends CascadingException
     String message = "unable to resolve scheme sink selector: " + selectorFields.printVerbose() +
       ", with incoming: " + incomingFields.printVerbose();
 
-    return Util.formatTrace( tap.getScheme(), message );
+    return TraceUtil.formatTrace( tap.getScheme(), message );
     }
   }

--- a/cascading-core/src/main/java/cascading/tap/partition/PartitionTapProps.java
+++ b/cascading-core/src/main/java/cascading/tap/partition/PartitionTapProps.java
@@ -33,6 +33,8 @@ public class PartitionTapProps extends Props
   {
   public static final String FAIL_ON_CLOSE = "cascading.tap.partition.failonclose";
 
+  private boolean failOnClose = false;
+
   /**
    * Method setFailOnClose(boolean b) controls if the PartitionTap is ignoring all Excpetions, when a TupleEntryCollector
    * is closed or if it should rethrow the Exception.
@@ -45,24 +47,21 @@ public class PartitionTapProps extends Props
     properties.put( FAIL_ON_CLOSE, Boolean.toString( failOnClose ) );
     }
 
-  private boolean failOnClose = false;
-
-  /***
-   * Constructs a new PartitionTapProps instance.
+  /**
+   * Creates a new PartitionTapProps instance.
+   *
+   * @return PartitionTapProps instance
    */
-  public PartitionTapProps()
-    {
-    }
-
   public static PartitionTapProps partitionTapProps()
     {
     return new PartitionTapProps();
     }
 
-  @Override
-  protected void addPropertiesTo( Properties properties )
+  /**
+   * Constructs a new PartitionTapProps instance.
+   */
+  public PartitionTapProps()
     {
-    setFailOnClose( properties, failOnClose );
     }
 
   public boolean isFailOnClose()
@@ -70,9 +69,21 @@ public class PartitionTapProps extends Props
     return failOnClose;
     }
 
+  /**
+   * Method setFailOnClose controls if the PartitionTap is ignoring all Exceptions, when a TupleEntryCollector
+   * is closed or if it should rethrow the Exception.
+   *
+   * @param failOnClose boolean controlling the close behaviour
+   */
   public PartitionTapProps setFailOnClose( boolean failOnClose )
     {
     this.failOnClose = failOnClose;
     return this;
+    }
+
+  @Override
+  protected void addPropertiesTo( Properties properties )
+    {
+    setFailOnClose( properties, failOnClose );
     }
   }

--- a/cascading-core/src/main/java/cascading/tuple/TupleEntrySchemeIteratorProps.java
+++ b/cascading-core/src/main/java/cascading/tuple/TupleEntrySchemeIteratorProps.java
@@ -21,11 +21,9 @@
 package cascading.tuple;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 
 import cascading.property.Props;
 import cascading.util.Util;
@@ -37,6 +35,8 @@ import cascading.util.Util;
 public class TupleEntrySchemeIteratorProps extends Props
   {
   public static final String PERMITTED_EXCEPTIONS = "cascading.tuple.tupleentryiterator.exceptions.permit";
+
+  private Class<? extends Exception>[] permittedExceptions = null;
 
   /**
    * Method setPermittedExceptions(  Map<Object, Object> properties, Class<? extends Exception>[] ... exceptions )
@@ -61,7 +61,15 @@ public class TupleEntrySchemeIteratorProps extends Props
       }
     }
 
-  private Class<? extends Exception>[] exceptions = null;
+  /**
+   * Creates a new TupleEntrySchemeIteratorProps instance.
+   *
+   * @return TupleEntrySchemeIteratorProps instance
+   */
+  public static TupleEntrySchemeIteratorProps tupleEntrySchemeIteratorProps()
+    {
+    return new TupleEntrySchemeIteratorProps();
+    }
 
   /**
    * Constructs a new TupleEntrySchemeIteratorProps instance.
@@ -70,25 +78,28 @@ public class TupleEntrySchemeIteratorProps extends Props
     {
     }
 
-  public static TupleEntrySchemeIteratorProps tupleEntrySchemeIteratorProps()
+  public Class<? extends Exception>[] getPermittedExceptions()
     {
-    return new TupleEntrySchemeIteratorProps();
+    return permittedExceptions;
+    }
+
+  /**
+   * Method setPermittedExceptions is used to set an array of exceptions which are allowed to be ignored in the
+   * TupleEntrySchemeIterator.
+   * <p/>
+   * If the array is null, it will be ignored.
+   *
+   * @param permittedExceptions an array of exception classes.
+   */
+  public TupleEntrySchemeIteratorProps setPermittedExceptions( Class<? extends Exception>[] permittedExceptions )
+    {
+    this.permittedExceptions = permittedExceptions;
+    return this;
     }
 
   @Override
   protected void addPropertiesTo( Properties properties )
     {
-    setPermittedExceptions( properties, exceptions );
-    }
-
-  public Class<? extends Exception>[] getExceptions()
-    {
-    return exceptions;
-    }
-
-  public TupleEntrySchemeIteratorProps setExceptions( Class<? extends Exception>[] exceptions )
-    {
-    this.exceptions = exceptions;
-    return this;
+    setPermittedExceptions( properties, permittedExceptions );
     }
   }

--- a/cascading-core/src/main/java/cascading/tuple/collect/SpillableProps.java
+++ b/cascading-core/src/main/java/cascading/tuple/collect/SpillableProps.java
@@ -37,7 +37,7 @@ import cascading.util.Util;
 public class SpillableProps extends Props
   {
   /**
-   * Whether to enable compress of the spills or not, on by default.
+   * Whether to enable compression of the spills or not, on by default.
    *
    * @see Boolean#parseBoolean(String)
    */
@@ -81,6 +81,11 @@ public class SpillableProps extends Props
   int mapInitialCapacity = defaultMapInitialCapacity;
   float mapLoadFactor = defaultMapLoadFactor;
 
+  /**
+   * Creates a new SpillableProps instance.
+   *
+   * @return SpillableProps instance
+   */
   public static SpillableProps spillableProps()
     {
     return new SpillableProps();
@@ -95,6 +100,14 @@ public class SpillableProps extends Props
     return compressSpill;
     }
 
+  /**
+   * Method setCompressSpill either enables or disables spill compression. Enabled by default.
+   * <p/>
+   * Spill compression relies on properly configured and available codecs. See {@link #setCodecs(java.util.List)}.
+   *
+   * @param compressSpill type boolean
+   * @return this
+   */
   public SpillableProps setCompressSpill( boolean compressSpill )
     {
     this.compressSpill = compressSpill;
@@ -107,6 +120,14 @@ public class SpillableProps extends Props
     return codecs;
     }
 
+  /**
+   * Method setCodecs sets list of possible codec class names to use. They will be loaded in order, if available.
+   * <p/>
+   * This is platform dependent.
+   *
+   * @param codecs type list
+   * @return this
+   */
   public SpillableProps setCodecs( List<String> codecs )
     {
     this.codecs = codecs;
@@ -114,6 +135,13 @@ public class SpillableProps extends Props
     return this;
     }
 
+  /**
+   * Method addCodecs adds a list of possible codec class names to use. They will be loaded in order, if available.
+   * <p/>
+   * This is platform dependent.
+   *
+   * @param codecs type list
+   */
   public SpillableProps addCodecs( List<String> codecs )
     {
     this.codecs.addAll( codecs );
@@ -121,6 +149,13 @@ public class SpillableProps extends Props
     return this;
     }
 
+  /**
+   * Method addCodec adds a codec class names to use.
+   * <p/>
+   * This is platform dependent.
+   *
+   * @param codec type String
+   */
   public SpillableProps addCodec( String codec )
     {
     this.codecs.add( codec );
@@ -133,6 +168,12 @@ public class SpillableProps extends Props
     return listSpillThreshold;
     }
 
+  /**
+   * Method setListSpillThreshold sets the number of tuples to hold in memory before spilling them to disk.
+   *
+   * @param listSpillThreshold of type int
+   * @return this
+   */
   public SpillableProps setListSpillThreshold( int listSpillThreshold )
     {
     this.listSpillThreshold = listSpillThreshold;
@@ -145,6 +186,14 @@ public class SpillableProps extends Props
     return mapSpillThreshold;
     }
 
+  /**
+   * Method setMapSpillThreshold the total number of tuple values (not keys) to attempt to keep in memory.
+   * <p/>
+   * The default implementation cannot spill Map keys to disk.
+   *
+   * @param mapSpillThreshold of type int
+   * @return this
+   */
   public SpillableProps setMapSpillThreshold( int mapSpillThreshold )
     {
     this.mapSpillThreshold = mapSpillThreshold;
@@ -157,6 +206,12 @@ public class SpillableProps extends Props
     return mapInitialCapacity;
     }
 
+  /**
+   * Method setMapInitialCapacity sets the default capacity to be used by the backing Map implementation.
+   *
+   * @param mapInitialCapacity type int
+   * @return this
+   */
   public SpillableProps setMapInitialCapacity( int mapInitialCapacity )
     {
     this.mapInitialCapacity = mapInitialCapacity;
@@ -169,6 +224,12 @@ public class SpillableProps extends Props
     return mapLoadFactor;
     }
 
+  /**
+   * Method setMapLoadFactor sets the default load factor to be used by the backing Map implementation.
+   *
+   * @param mapLoadFactor type float
+   * @return this
+   */
   public SpillableProps setMapLoadFactor( float mapLoadFactor )
     {
     this.mapLoadFactor = mapLoadFactor;

--- a/cascading-core/src/main/java/cascading/util/TraceUtil.java
+++ b/cascading-core/src/main/java/cascading/util/TraceUtil.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2007-2014 Concurrent, Inc. All Rights Reserved.
+ *
+ * Project and contact information: http://www.cascading.org/
+ *
+ * This file is part of the Cascading project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cascading.util;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+
+import cascading.operation.BaseOperation;
+import cascading.operation.Operation;
+import cascading.pipe.Pipe;
+import cascading.scheme.Scheme;
+import cascading.tap.Tap;
+
+/**
+ *
+ */
+public class TraceUtil
+  {
+  /**
+   * The set of regex patterns specifying fully qualified class or package names that serve as boundaries
+   * for collecting traces and apiCalls in captureDebugTraceAndApiCall.
+   */
+  private static final Map<String, Pattern> registeredApiBoundaries = new ConcurrentHashMap<String, Pattern>();
+
+  private static interface TraceFormatter
+    {
+    String format( String trace );
+    }
+
+  /**
+   * Add a regex that serves as a boundary for tracing. That is to say any trace
+   * captured by {@link #captureDebugTrace(Object)} will be from a caller that comes higher in the
+   * stack than any apiBoundary package or class.
+   *
+   * @param apiBoundary
+   */
+  public static void registerApiBoundary( String apiBoundary )
+    {
+    registeredApiBoundaries.put( apiBoundary, Pattern.compile( apiBoundary ) );
+    }
+
+  /**
+   * Remove a regex as a boundary for tracing. See registerApiBoundary.
+   *
+   * @param apiBoundary
+   */
+  public static void unregisterApiBoundary( String apiBoundary )
+    {
+    registeredApiBoundaries.remove( apiBoundary );
+    }
+
+  /**
+   * Allows for custom trace fields on Pipe, Tap, and Scheme types
+   *
+   * @param object
+   * @param trace
+   */
+  public static void setTrace( Object object, String trace )
+    {
+    Util.setInstanceFieldIfExists( object, "trace", trace );
+    }
+
+  private static String formatTrace( Traceable traceable, String message, TraceFormatter formatter )
+    {
+    if( traceable == null )
+      return message;
+
+    String trace = traceable.getTrace();
+
+    if( trace == null )
+      return message;
+
+    return formatter.format( trace ) + " " + message;
+    }
+
+  public static String formatTrace( final Scheme scheme, String message )
+    {
+    return formatTrace( scheme, message, new TraceFormatter()
+    {
+    @Override
+    public String format( String trace )
+      {
+      return "[" + Util.truncate( scheme.toString(), 25 ) + "][" + trace + "]";
+      }
+    } );
+    }
+
+  /**
+   * Method formatRawTrace does not include the pipe name
+   *
+   * @param pipe    of type Pipe
+   * @param message of type String
+   * @return String
+   */
+  public static String formatRawTrace( Pipe pipe, String message )
+    {
+    return formatTrace( pipe, message, new TraceFormatter()
+    {
+    @Override
+    public String format( String trace )
+      {
+      return "[" + trace + "]";
+      }
+    } );
+    }
+
+  public static String formatTrace( final Pipe pipe, String message )
+    {
+    return formatTrace( pipe, message, new TraceFormatter()
+    {
+    @Override
+    public String format( String trace )
+      {
+      return "[" + Util.truncate( pipe.getName(), 25 ) + "][" + trace + "]";
+      }
+    } );
+    }
+
+  public static String formatTrace( final Tap tap, String message )
+    {
+    return formatTrace( tap, message, new TraceFormatter()
+    {
+    @Override
+    public String format( String trace )
+      {
+      return "[" + Util.truncate( tap.toString(), 25 ) + "][" + trace + "]";
+      }
+    } );
+    }
+
+  public static String formatTrace( Operation operation, String message )
+    {
+    if( !( operation instanceof BaseOperation ) )
+      return message;
+
+    String trace = ( (BaseOperation) operation ).getTrace();
+
+    if( trace == null )
+      return message;
+
+    return "[" + trace + "] " + message;
+    }
+
+  public static String captureDebugTrace( Object target )
+    {
+    StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+
+    StackTraceElement candidateUserCodeElement = null;
+    StackTraceElement apiCallElement = null;
+    Class<?> tracingBoundary = target.getClass();
+    String boundaryClassName = tracingBoundary.getName();
+
+    // walk from the bottom of the stack(which is at the end of the array) upwards towards any boundary.
+    // The apiCall is the element at the boundary and the previous stack element is the user code
+    for( int i = stackTrace.length - 1; i >= 0; i-- )
+      {
+      StackTraceElement stackTraceElement = stackTrace[ i ];
+      String stackClassName = stackTraceElement.getClassName();
+
+      if( stackClassName != null && ( stackClassName.startsWith( boundaryClassName ) || atApiBoundary( stackTraceElement.toString() ) ) )
+        {
+        apiCallElement = stackTraceElement;
+        break;
+        }
+
+      candidateUserCodeElement = stackTraceElement;
+      }
+
+    String userCode = candidateUserCodeElement == null ? "" : candidateUserCodeElement.toString();
+    String apiCall = "";
+
+    if( apiCallElement != null )
+      {
+      String method = apiCallElement.getMethodName();
+
+      if( method.equals( "<init>" ) )
+        apiCall = String.format( "new %s()", getSimpleClassName( apiCallElement.getClassName() ) );
+      else
+        apiCall = String.format( "%s()", method );
+      }
+
+    return userCode.isEmpty() ? apiCall : apiCall.isEmpty() ? userCode : String.format( "%s @ %s", apiCall, userCode );
+    }
+
+  private static Object getSimpleClassName( String className )
+    {
+    if( className == null || className.isEmpty() )
+      return "";
+
+    String parts[] = className.split( "\\." );
+
+    if( parts.length == 0 )
+      return "";
+
+    return parts[ parts.length - 1 ];
+    }
+
+  private static boolean atApiBoundary( String stackTraceElement )
+    {
+    for( Pattern boundary : registeredApiBoundaries.values() )
+      {
+      if( boundary.matcher( stackTraceElement ).matches() )
+        return true;
+      }
+
+    return false;
+    }
+  }

--- a/cascading-core/src/main/java/cascading/util/TraceUtil.java
+++ b/cascading-core/src/main/java/cascading/util/TraceUtil.java
@@ -176,9 +176,15 @@ public class TraceUtil
       StackTraceElement stackTraceElement = stackTrace[ i ];
       String stackClassName = stackTraceElement.getClassName();
 
-      if( stackClassName != null && ( stackClassName.startsWith( boundaryClassName ) || atApiBoundary( stackTraceElement.toString() ) ) )
+      boolean atApiBoundary = atApiBoundary( stackTraceElement.toString() );
+      if( ( stackClassName != null && ( stackClassName.startsWith( boundaryClassName ) ) || atApiBoundary ) )
         {
-        apiCallElement = stackTraceElement;
+        // only record the apiCallElement if we're at an apiBoundary. That means
+        // Trace will only have "apiMethod() @ call_location" when a registered
+        // api boundary is found. The default for Cascading will just have
+        // call_location.
+        if (atApiBoundary)
+          apiCallElement = stackTraceElement;
         break;
         }
 

--- a/cascading-core/src/main/java/cascading/util/Traceable.java
+++ b/cascading-core/src/main/java/cascading/util/Traceable.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2007-2014 Concurrent, Inc. All Rights Reserved.
+ *
+ * Project and contact information: http://www.cascading.org/
+ *
+ * This file is part of the Cascading project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cascading.util;
+
+/**
+ * Indicates that a class has trace fields usable from TraceUtil
+ */
+public interface Traceable
+  {
+  /**
+   * Method getTrace returns a String that pinpoints the caller that created this instance.
+   *
+   * @return String
+   */
+  String getTrace();
+  }

--- a/cascading-core/src/main/java/cascading/util/Util.java
+++ b/cascading-core/src/main/java/cascading/util/Util.java
@@ -48,10 +48,6 @@ import cascading.CascadingException;
 import cascading.flow.FlowElement;
 import cascading.flow.FlowException;
 import cascading.flow.planner.Scope;
-import cascading.operation.BaseOperation;
-import cascading.operation.Operation;
-import cascading.pipe.Pipe;
-import cascading.scheme.Scheme;
 import cascading.tap.MultiSourceTap;
 import cascading.tap.Tap;
 import org.jgrapht.ext.DOTExporter;
@@ -444,7 +440,7 @@ public class Util
       }
     }
 
-  @SuppressWarnings({"unchecked"})
+  @SuppressWarnings( {"unchecked"} )
   private static void printGraph( Writer writer, SimpleDirectedGraph graph )
     {
     DOTExporter dot = new DOTExporter( new IntegerNameProvider(), new VertexNameProvider()
@@ -481,7 +477,7 @@ public class Util
    *
    * @param list
    */
-  @SuppressWarnings({"StatementWithEmptyBody"})
+  @SuppressWarnings( {"StatementWithEmptyBody"} )
   public static void removeAllNulls( List list )
     {
     while( list.remove( null ) )
@@ -491,115 +487,21 @@ public class Util
   /**
    * Allows for custom trace fields on Pipe, Tap, and Scheme types
    *
-   * @param object
-   * @param trace
+   * @deprecated see {@link cascading.util.TraceUtil#setTrace(Object, String)}
    */
+  @Deprecated
   public static void setTrace( Object object, String trace )
     {
-    setInstanceFieldIfExists( object, "trace", trace );
-    }
-
-  public static String formatTrace( Scheme scheme, String message )
-    {
-    if( scheme == null )
-      return message;
-
-    String trace = scheme.getTrace();
-
-    if( trace == null )
-      return message;
-
-    return "[" + truncate( scheme.toString(), 25 ) + "][" + trace + "] " + message;
+    TraceUtil.setTrace( object, trace );
     }
 
   /**
-   * Method formatRawTrace does not include the pipe name
-   *
-   * @param pipe    of type Pipe
-   * @param message of type String
-   * @return String
+   * @deprecated see {@link cascading.util.TraceUtil#captureDebugTrace(Object)}
    */
-  public static String formatRawTrace( Pipe pipe, String message )
-    {
-    if( pipe == null )
-      return message;
-
-    String trace = pipe.getTrace();
-
-    if( trace == null )
-      return message;
-
-    return "[" + trace + "] " + message;
-    }
-
-  public static String formatTrace( Pipe pipe, String message )
-    {
-    if( pipe == null )
-      return message;
-
-    String trace = pipe.getTrace();
-
-    if( trace == null )
-      return message;
-
-    return "[" + truncate( pipe.getName(), 25 ) + "][" + trace + "] " + message;
-    }
-
-  public static String formatTrace( Tap tap, String message )
-    {
-    if( tap == null )
-      return message;
-
-    String trace = tap.getTrace();
-
-    if( trace == null )
-      return message;
-
-    return "[" + truncate( tap.toString(), 25 ) + "][" + trace + "] " + message;
-    }
-
-  public static String formatTrace( Operation operation, String message )
-    {
-    if( !( operation instanceof BaseOperation ) )
-      return message;
-
-    String trace = ( (BaseOperation) operation ).getTrace();
-
-    if( trace == null )
-      return message;
-
-    return "[" + trace + "] " + message;
-    }
-
+  @Deprecated
   public static String captureDebugTrace( Class type )
     {
-    StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
-    Package packageName = type.getPackage();
-    String typeName = type.getName();
-
-    boolean skip = true;
-
-    for( StackTraceElement stackTraceElement : stackTrace )
-      {
-      String className = stackTraceElement.getClassName();
-
-      if( skip )
-        {
-        skip = !className.equals( typeName );
-        continue;
-        }
-      else
-        {
-        if( packageName != null && stackTraceElement.getClassName().equals( typeName ) )
-          {
-          continue;
-          }
-        }
-
-      return stackTraceElement.toString();
-      }
-
-    return null;
+    return TraceUtil.captureDebugTrace( type );
     }
 
   public static void writeDOT( Writer writer, SimpleDirectedGraph graph, IntegerNameProvider vertexIdProvider, VertexNameProvider vertexNameProvider, EdgeNameProvider edgeNameProvider )
@@ -874,7 +776,7 @@ public class Util
       }
     }
 
-  public static <T> T newInstance( String className, Object... parameters)
+  public static <T> T newInstance( String className, Object... parameters )
     {
     try
       {
@@ -888,7 +790,7 @@ public class Util
       }
     }
 
-  public static <T> T newInstance( Class<T> target, Object... parameters)
+  public static <T> T newInstance( Class<T> target, Object... parameters )
     {
     // using Expression makes sure that constructors using sub-types properly work, otherwise we get a
     // NoSuchMethodException.

--- a/cascading-core/src/test/java/cascading/TraceTest.java
+++ b/cascading-core/src/test/java/cascading/TraceTest.java
@@ -40,6 +40,7 @@ import cascading.tap.Tap;
 import cascading.tuple.Fields;
 import cascading.tuple.TupleEntryCollector;
 import cascading.tuple.TupleEntryIterator;
+import cascading.util.TraceUtil;
 import org.junit.Test;
 
 /**
@@ -154,6 +155,34 @@ public class TraceTest extends CascadingTestCase
     assertEqualsTrace( "cascading.TraceTest.testPipeAssemblyDeep(TraceTest.java", pipe.getTrace() );
     assertEqualsTrace( "cascading.TraceTest$TestSubAssembly.<init>(TraceTest.java", pipe.pipe.getTrace() );
     assertEqualsTrace( "cascading.TraceTest$TestSubAssembly.<init>(TraceTest.java", pipe.getTails()[ 0 ].getTrace() );
+    }
+
+  public static Pipe sampleApi()
+    {
+    return new Pipe( "foo" );
+    }
+
+  @Test
+  public void testApiBoundary()
+    {
+    final String regex = "cascading\\.TraceTest\\.sampleApi.*";
+
+    TraceUtil.registerApiBoundary( regex );
+
+    try
+      {
+      Pipe pipe1 = sampleApi();
+
+      assertEqualsTrace( "sampleApi() @ cascading.TraceTest.testApiBoundary(TraceTest.java", pipe1.getTrace() );
+      }
+    finally
+      {
+      TraceUtil.unregisterApiBoundary( regex );
+      }
+
+    Pipe pipe2 = sampleApi();
+
+    assertEqualsTrace( "new Pipe() @ cascading.TraceTest.sampleApi(TraceTest.java", pipe2.getTrace() );
     }
 
   @Test

--- a/cascading-core/src/test/java/cascading/TraceTest.java
+++ b/cascading-core/src/test/java/cascading/TraceTest.java
@@ -182,7 +182,7 @@ public class TraceTest extends CascadingTestCase
 
     Pipe pipe2 = sampleApi();
 
-    assertEqualsTrace( "new Pipe() @ cascading.TraceTest.sampleApi(TraceTest.java", pipe2.getTrace() );
+    assertEqualsTrace( "cascading.TraceTest.sampleApi(TraceTest.java", pipe2.getTrace() );
     }
 
   @Test

--- a/cascading-hadoop/src/main/shared/cascading/tap/hadoop/HfsProps.java
+++ b/cascading-hadoop/src/main/shared/cascading/tap/hadoop/HfsProps.java
@@ -107,7 +107,6 @@ public class HfsProps extends Props
       properties.put( COMBINE_INPUT_FILES_SAFE_MODE, Boolean.toString( safeMode ) );
     }
 
-
   /**
    * Method setCombinedInputMaxSize sets the maximum input split size to be used.
    * <p/>
@@ -120,6 +119,16 @@ public class HfsProps extends Props
     {
     if( size != null )
       properties.put( COMBINE_INPUT_FILES_SIZE_MAX, Long.toString( size ) );
+    }
+
+  /**
+   * Creates a new HfsProps instance.
+   *
+   * @return HfsProps instance
+   */
+  public static HfsProps hfsProps()
+    {
+    return new HfsProps();
     }
 
   public HfsProps()
@@ -225,7 +234,6 @@ public class HfsProps extends Props
 
     return this;
     }
-
 
   @Override
   protected void addPropertiesTo( Properties properties )

--- a/cascading-hadoop/src/main/shared/cascading/tuple/hadoop/TupleSerializationProps.java
+++ b/cascading-hadoop/src/main/shared/cascading/tuple/hadoop/TupleSerializationProps.java
@@ -84,6 +84,11 @@ public class TupleSerializationProps extends Props
     properties.put( HADOOP_IO_SERIALIZATIONS, Util.join( ",", Util.removeNulls( serializations, className ) ) );
     }
 
+  /**
+   * Creates a new TupleSerializationProps instance.
+   *
+   * @return TupleSerializationProps instance
+   */
   public static TupleSerializationProps tupleSerializationProps()
     {
     return new TupleSerializationProps();
@@ -98,6 +103,15 @@ public class TupleSerializationProps extends Props
     return serializationTokens;
     }
 
+  /**
+   * Method setSerializationTokens sets the given integer tokens and classNames Map as a serialization properties.
+   * <p/>
+   * During object serialization and deserialization, the given tokens will be used instead of the className when an
+   * instance of the className is encountered.
+   *
+   * @param serializationTokens Map of Integer tokens and String classnames
+   * @return this
+   */
   public TupleSerializationProps setSerializationTokens( Map<Integer, String> serializationTokens )
     {
     this.serializationTokens = serializationTokens;
@@ -105,6 +119,15 @@ public class TupleSerializationProps extends Props
     return this;
     }
 
+  /**
+   * Method addSerializationTokens adds the given integer tokens and classNames Map as a serialization properties.
+   * <p/>
+   * During object serialization and deserialization, the given tokens will be used instead of the className when an
+   * instance of the className is encountered.
+   *
+   * @param serializationTokens Map of Integer tokens and String classnames
+   * @return this
+   */
   public TupleSerializationProps addSerializationTokens( Map<Integer, String> serializationTokens )
     {
     this.serializationTokens.putAll( serializationTokens );
@@ -112,9 +135,19 @@ public class TupleSerializationProps extends Props
     return this;
     }
 
-  public TupleSerializationProps addSerializationToken( int token, String serialization )
+  /**
+   * Method addSerializationToken adds the given integer token and classNames as a serialization properties.
+   * <p/>
+   * During object serialization and deserialization, the given tokens will be used instead of the className when an
+   * instance of the className is encountered.
+   *
+   * @param token                  type int
+   * @param serializationClassName type String
+   * @return this
+   */
+  public TupleSerializationProps addSerializationToken( int token, String serializationClassName )
     {
-    this.serializationTokens.put( token, serialization );
+    this.serializationTokens.put( token, serializationClassName );
 
     return this;
     }
@@ -124,23 +157,41 @@ public class TupleSerializationProps extends Props
     return hadoopSerializations;
     }
 
-  public TupleSerializationProps setHadoopSerializations( List<String> hadoopSerializations )
+  /**
+   * Method setHadoopSerializations sets the Hadoop serialization classNames to be used as properties.
+   *
+   * @param hadoopSerializationClassNames List of classNames
+   * @return this
+   */
+  public TupleSerializationProps setHadoopSerializations( List<String> hadoopSerializationClassNames )
     {
-    this.hadoopSerializations = hadoopSerializations;
+    this.hadoopSerializations = hadoopSerializationClassNames;
 
     return this;
     }
 
-  public TupleSerializationProps addHadoopSerializations( List<String> hadoopSerializations )
+  /**
+   * Method addHadoopSerializations adds the Hadoop serialization classNames to be used as properties.
+   *
+   * @param hadoopSerializationClassNames List of classNames
+   * @return this
+   */
+  public TupleSerializationProps addHadoopSerializations( List<String> hadoopSerializationClassNames )
     {
-    this.hadoopSerializations.addAll( hadoopSerializations );
+    this.hadoopSerializations.addAll( hadoopSerializationClassNames );
 
     return this;
     }
 
-  public TupleSerializationProps addHadoopSerialization( String hadoopSerialization )
+  /**
+   * Method addHadoopSerialization adds a Hadoop serialization className to be used as properties.
+   *
+   * @param hadoopSerializationClassName List of classNames
+   * @return this
+   */
+  public TupleSerializationProps addHadoopSerialization( String hadoopSerializationClassName )
     {
-    this.hadoopSerializations.add( hadoopSerialization );
+    this.hadoopSerializations.add( hadoopSerializationClassName );
 
     return this;
     }


### PR DESCRIPTION
Add a concept of an API boundary to tracing.

This PR adds a way to register an API boundary so that when an API such as
Scalding is used traces from Pipe, Tap, Scheme, and BaseOperation point to
user code rather than Scalding code. APIs must register a regex with
Util which keeps track of all registered boundaries and uses them to 
determine the trace point. In addition, a new field is added along side
trace that points to the API the user code called. That allows a Document
Service to make note of the fact that, e.g., Scalding's RichPipe.map(), was
what the user code called.
