### PR TITLE
Make TupleHasher.ObjectHasher serializable

### DIFF
--- a/cascading-core/src/main/java/cascading/tuple/util/TupleHasher.java
+++ b/cascading-core/src/main/java/cascading/tuple/util/TupleHasher.java
@@ -125,7 +125,7 @@ public class TupleHasher implements Serializable
     return hashFunction;
     }
 
-  private static class ObjectHasher implements Hasher<Object>
+  private static class ObjectHasher implements Hasher<Object>, Serializable
     {
     @Override
     public int hashCode( Object value )


### PR DESCRIPTION
Fixes NotSerializableException exception when using Unique and custom comparators.
