### PR TITLE
Fix node injection BeforeEachEdge and AfterEachEdge

### DIFF
--- a/cascading-core/src/main/java/cascading/flow/planner/graph/ElementGraphs.java
+++ b/cascading-core/src/main/java/cascading/flow/planner/graph/ElementGraphs.java
@@ -565,6 +565,26 @@ public class ElementGraphs
       }
     }
 
+	  public static void insertFlowElementBetweenEdge( ElementGraph elementGraph, Scope previousEdge, FlowElement newElement )
+	  {
+
+		  FlowElement previousElement = elementGraph.getEdgeSource(previousEdge);
+		  FlowElement nextElement = elementGraph.getEdgeTarget(previousEdge);
+
+		  elementGraph.addVertex( newElement );
+
+		  // add edge between previous and new
+		  elementGraph.addEdge( previousElement, newElement, new Scope(previousEdge));
+
+		  // add edge between new and next
+		  Scope s = new Scope(previousEdge);
+		  s.setOrdinal(previousEdge.getOrdinal());
+		  elementGraph.addEdge( newElement, nextElement, s);
+
+		  // remove previous edge
+		  elementGraph.removeEdge(previousElement, nextElement);
+	  }
+
   public static void addSources( BaseFlowStep flowStep, ElementGraph elementGraph, Set<Tap> sources )
     {
     for( Tap tap : sources )

--- a/cascading-core/src/main/java/cascading/flow/planner/iso/transformer/InsertionGraphTransformer.java
+++ b/cascading-core/src/main/java/cascading/flow/planner/iso/transformer/InsertionGraphTransformer.java
@@ -20,10 +20,12 @@
 
 package cascading.flow.planner.iso.transformer;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import cascading.flow.FlowElement;
+import cascading.flow.planner.Scope;
 import cascading.flow.planner.graph.ElementGraph;
 import cascading.flow.planner.graph.ElementGraphs;
 import cascading.flow.planner.iso.expression.ElementCapture;
@@ -128,21 +130,23 @@ public class InsertionGraphTransformer extends MutateGraphTransformer
 
         case BeforeEachEdge:
 
-          List<FlowElement> predecessors = graph.predecessorListOf( flowElement );
+		  Set<Scope> incommingEdges = new HashSet<>(graph.incomingEdgesOf( flowElement ));
 
-          for( FlowElement predecessor : predecessors )
-            ElementGraphs.insertFlowElementAfter( graph, predecessor, elementFactory.create( graph, predecessor ) );
-
+		  for( Scope incomingEdge : incommingEdges) {
+			  FlowElement predecessor = graph.getEdgeSource(incomingEdge);
+			  ElementGraphs.insertFlowElementBetweenEdge( graph, incomingEdge, elementFactory.create( graph, predecessor ));
+		  }
           break;
 
         case AfterEachEdge:
 
-          List<FlowElement> successors = graph.successorListOf( flowElement );
+			Set<Scope> outgoingEdges = new HashSet<>(graph.outgoingEdgesOf(flowElement));
 
-          for( FlowElement successor : successors )
-            ElementGraphs.insertFlowElementBefore( graph, successor, elementFactory.create( graph, successor ) );
-
-          break;
+			for( Scope outgoingEdge : outgoingEdges) {
+				FlowElement successor = graph.getEdgeTarget(outgoingEdge);
+				ElementGraphs.insertFlowElementBetweenEdge( graph, outgoingEdge, elementFactory.create( graph, successor ));
+			}
+			break;
         }
       }
 


### PR DESCRIPTION
This PR changes the behavior of `RuleInsertionTransformer` when inserting nodes before or after each edge. Right now, inserting a new node `AfterEachEdge` of node X is implemented as inserting a node `Before` each successor of X. Inserting `BeforeEachEdge` is inversely handled.

I found two issues with that:

1) Given a flow:

```
Source_1 -> Each_1 -> Merge -> Sink
Source_2 -> Each_2 __/
```

and a rule that inserts a new `Boundary` node `AfterEachEdge` of `Each_1`, 
should result in:

```
Source_1 -> Each_1 -> Boundary -> Merge -> Sink
Source_2 -> Each_2 ______________/
```

but will result in:

```
Source_1 -> Each_1 -> Boundary -> Merge -> Sink
Source_2 -> Each_2 __/
```

The `BeforeEachEdge` case will be inversely handled.

2) In case of an `AfterEachEdge` insertion after a node X, the scope between the new node and the original successor of X will have the name of the successor node of X (due to the implementation of `ElementGraphs.insertFlowElementBefore()`). If the successor is a `Splice` resolving keys against incoming scopes might fail because of the new scope with invalid name. Depending on the contract of `ElementGraphs.insertFlowElementBefore()`, the naming of the scope might also be a bug in that method.

This PR fixes the problem, by replacing each outgoing/incoming scope by a new node with one incoming and one outgoing scope. Both new scopes have the name of the replaced scopes.

It seems that `Before` and `BeforeEachEdge` are not used in the Cascading code base and `AfterEachEdge` only once. 
**Note** I only ran local tests (`gradle clean cascading-local:test cascading-local:platformTest`).
