### PR TITLE
Made MeasuredOutputCollector implement Flushable so it's consistent w…

### DIFF
--- a/cascading-hadoop/src/main/shared-io/cascading/tap/hadoop/util/MeasuredOutputCollector.java
+++ b/cascading-hadoop/src/main/shared-io/cascading/tap/hadoop/util/MeasuredOutputCollector.java
@@ -21,6 +21,7 @@
 package cascading.tap.hadoop.util;
 
 import java.io.Closeable;
+import java.io.Flushable;
 import java.io.IOException;
 
 import cascading.flow.FlowProcess;
@@ -29,7 +30,7 @@ import org.apache.hadoop.mapred.OutputCollector;
 /**
  *
  */
-public class MeasuredOutputCollector implements OutputCollector, Closeable
+public class MeasuredOutputCollector implements OutputCollector, Flushable, Closeable
   {
   private final FlowProcess flowProcess;
   private final Enum counter;
@@ -72,6 +73,13 @@ public class MeasuredOutputCollector implements OutputCollector, Closeable
       {
       flowProcess.increment( counter, System.currentTimeMillis() - start );
       }
+    }
+
+  @Override
+  public void flush() throws IOException
+    {
+    if( outputCollector instanceof Flushable )
+      ( (Flushable) outputCollector ).flush();
     }
 
   @Override

--- a/cascading-hadoop2-tez/src/main/java/cascading/flow/tez/stream/element/OldOutputCollector.java
+++ b/cascading-hadoop2-tez/src/main/java/cascading/flow/tez/stream/element/OldOutputCollector.java
@@ -20,22 +20,27 @@
 
 package cascading.flow.tez.stream.element;
 
+import java.io.Closeable;
+import java.io.Flushable;
 import java.io.IOException;
 
 import cascading.CascadingException;
 import org.apache.hadoop.mapred.OutputCollector;
+import org.apache.tez.mapreduce.output.MROutput;
 import org.apache.tez.runtime.api.LogicalOutput;
 import org.apache.tez.runtime.library.api.KeyValueWriter;
 
 /**
  *
  */
-class OldOutputCollector implements OutputCollector
+class OldOutputCollector implements OutputCollector, Flushable, Closeable
   {
+  private final LogicalOutput logicalOutput;
   private final KeyValueWriter output;
 
   OldOutputCollector( LogicalOutput logicalOutput )
     {
+    this.logicalOutput = logicalOutput;
     try
       {
       this.output = (KeyValueWriter) logicalOutput.getWriter();
@@ -49,5 +54,19 @@ class OldOutputCollector implements OutputCollector
   public void collect( Object key, Object value ) throws IOException
     {
     output.write( key, value );
+    }
+
+  @Override
+  public void flush() throws IOException
+    {
+    if( logicalOutput instanceof MROutput )
+      ( (MROutput) logicalOutput ).flush();
+    }
+
+  @Override
+  public void close() throws IOException
+    {
+    if( logicalOutput instanceof MROutput )
+      ( (MROutput) logicalOutput ).close();
     }
   }


### PR DESCRIPTION
…ith HadoopTupleEntrySchemeCollector.close(). And OldOutputCollector implement Flushable and Closeable so we can call flush and close on MROutput
