### PR TITLE
Fixes handling and passing of Fields types

### DIFF
--- a/cascading-core/src/main/java/cascading/pipe/Operator.java
+++ b/cascading-core/src/main/java/cascading/pipe/Operator.java
@@ -20,6 +20,7 @@
 
 package cascading.pipe;
 
+import java.lang.reflect.Type;
 import java.util.Set;
 
 import cascading.flow.planner.Scope;
@@ -282,7 +283,7 @@ public abstract class Operator extends Pipe
       return declaredFields;
 
     if( outputSelector.isArguments() )
-      return argumentFields;
+      return argumentFields.applyTypes( ( Type[] ) null );
 
     if( outputSelector.isGroup() )
       return incomingScope.getOutGroupingFields();
@@ -345,7 +346,7 @@ public abstract class Operator extends Pipe
         throw new OperatorException( this, "during REPLACE both the arguments selector and field declaration must be the same size, arguments: " + arguments.printVerbose() + " declaration: " + fieldDeclaration.printVerbose() );
 
       if( fieldDeclaration.isArguments() ) // there is no type info, so inherit it
-        return arguments;
+        return arguments.applyTypes( ( Type[] ) null );
 
       return arguments.project( fieldDeclaration );
       }
@@ -358,7 +359,7 @@ public abstract class Operator extends Pipe
         return fieldDeclaration;
 
       if( fieldDeclaration.isArguments() )
-        return Fields.asDeclaration( arguments );
+        return Fields.asDeclaration( arguments.applyTypes( ( Type[] ) null ) );
 
       if( fieldDeclaration.isAll() )
         return resolveIncomingOperationPassThroughFields( incomingScope );

--- a/cascading-core/src/main/java/cascading/tuple/Fields.java
+++ b/cascading-core/src/main/java/cascading/tuple/Fields.java
@@ -464,11 +464,11 @@ public class Fields implements Comparable, Iterable<Comparable>, Serializable, C
         for( int i = 1; i < fields.length; i++ )
           {
           Type[] fieldTypes = fields[ i ].getTypes();
-          if( fieldTypes == null )
-            continue;
-
-          for( int j = 0; j < fieldTypes.length; j++ )
-            fields[ 0 ] = fields[ 0 ].applyType( fields[ i ].get( j ), fieldTypes[ j ] );
+          if ( fieldTypes == null )
+            fields[ 0 ] = fields[ 0 ].applyTypes( ( Type[] ) null );
+          else
+            for ( int j = 0; j < fieldTypes.length; j++ )
+              fields[ 0 ] = fields[ 0 ].applyType( fields[ i ].get( j ), fieldTypes[ j ] );
           }
         }
 

--- a/cascading-core/src/main/java/cascading/tuple/Fields.java
+++ b/cascading-core/src/main/java/cascading/tuple/Fields.java
@@ -1677,7 +1677,7 @@ public class Fields implements Comparable, Iterable<Comparable>, Serializable, C
 
     Fields results = new Fields( fields );
 
-    results.types = this.types == null ? new Type[ size() ] : this.types;
+    results.types = this.types == null ? new Type[ size() ] : copyTypes(this.types, this.types.length);
     results.types[ pos ] = type;
 
     return results;


### PR DESCRIPTION
I think I found three cases in which Field types are not correctly handled or forwarded:
- Fields.apply() does modify itself
- Using Fields.ARGS should remove types from the input types, because fields are only renamed but their type may change
- Fields.resolve() should remove types from the selector fields if the other types do not provide new types
