### PR TITLE
cleanup temporary directory with Tez & PartitionTap

### DIFF
--- a/cascading-hadoop2-tez/src/main/java/cascading/flow/tez/Hadoop2TezFlowStep.java
+++ b/cascading-hadoop2-tez/src/main/java/cascading/flow/tez/Hadoop2TezFlowStep.java
@@ -59,6 +59,7 @@ import cascading.property.AppProps;
 import cascading.tap.Tap;
 import cascading.tap.hadoop.Hfs;
 import cascading.tap.hadoop.PartitionTap;
+import cascading.tap.hadoop.util.Hadoop18TapUtil;
 import cascading.tuple.Fields;
 import cascading.tuple.hadoop.TupleSerialization;
 import cascading.tuple.hadoop.util.GroupingSortingComparator;
@@ -787,9 +788,36 @@ public class Hadoop2TezFlowStep extends BaseFlowStep<TezConfiguration>
     }
 
   @Override
-  public void clean( TezConfiguration entries )
+  public void clean( TezConfiguration config )
     {
+    if( getSink().isTemporary() && ( getFlow().getFlowStats().isSuccessful() || getFlow().getRunID() == null ) )
+      {
+      try
+        {
+        getSink().deleteResource( config );
+        }
+      catch( Exception exception )
+        {
+        // sink all exceptions, don't fail app
+        logWarn( "unable to remove temporary file: " + getSink(), exception );
+        }
+      }
+    else
+      {
+      cleanTapMetaData( config, getSink() );
+      }
+    }
 
+  private void cleanTapMetaData( TezConfiguration config, Tap tap )
+    {
+    try
+      {
+      Hadoop18TapUtil.cleanupTapMetaData( config, tap );
+      }
+    catch( IOException exception )
+      {
+      // ignore exception
+      }
     }
 
   public void syncArtifacts()


### PR DESCRIPTION
Following up from here: https://groups.google.com/d/topic/cascading-user/y7DxKcdAMXQ/discussion

There's 2 commits. The 1st is a failing test case and the 2nd is the fix.

The fix is pretty much a copy-paste from `HadoopFlowStep#clean`. Though, I've only included the cleanup of the sink, not the `tempSink` cleanup or the `HadoopUtil.removeStateFromDistCache` call. I'm not entirely sure what should be done there. Let me know and I can amend.
