### PR TITLE
    New test case for a deadlock in Fork/CoGroup/HashJoin structures …

### DIFF
--- a/cascading-local/src/main/java/cascading/flow/local/stream/duct/ParallelFork.java
+++ b/cascading-local/src/main/java/cascading/flow/local/stream/duct/ParallelFork.java
@@ -1,0 +1,214 @@
+package cascading.flow.local.stream.duct;
+
+import cascading.flow.stream.duct.Duct;
+import cascading.flow.stream.duct.Fork;
+import cascading.tuple.TupleEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.ref.WeakReference;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.util.ArrayList;
+import java.util.concurrent.*;
+
+/**
+ * This "Fork" avoids a possible deadlock in Fork-and-Join scenarios by running downstream edges into parallel threads.
+ *
+ * Forked from cascading.flow.stream.duct.Fork by Cyrille Chepelov <cch@transparencyrights.com> on 2016-01-07.
+ */
+public class ParallelFork<Outgoing> extends Fork<TupleEntry, Outgoing> {
+
+    private static final Logger LOG = LoggerFactory.getLogger( ParallelFork.class );
+
+    abstract static class Message {
+        final protected Duct previous;
+
+        public Message(Duct previous) {
+            this.previous = previous;
+        }
+
+        abstract public void passOn(Duct next);
+        abstract public boolean isTermination();
+    }
+
+    static final class StartMessage extends Message {
+        final CountDownLatch startLatch;
+
+        public StartMessage(Duct previous, CountDownLatch startLatch) {
+            super(previous);
+            this.startLatch = startLatch;
+        }
+        public void passOn(Duct next) {
+            startLatch.countDown();
+            next.start(previous);
+        }
+        public boolean isTermination() { return false; }
+    }
+
+    static final class ReceiveMessage extends Message {
+        final TupleEntry tuple;
+
+        public ReceiveMessage(Duct previous, TupleEntry tuple) {
+            super(previous);
+            this.tuple = new TupleEntry(tuple); /* we make a new copy right here, to avoid cross-thread trouble when upstream changes the tuple */
+        }
+        public void passOn(Duct next) {
+            next.receive(previous, tuple);
+        }
+        public boolean isTermination() { return false; }
+    }
+
+    static final class CompleteMessage extends Message {
+        public CompleteMessage(Duct previous) {
+            super(previous);
+        }
+        public void passOn(Duct next) {
+            next.complete(previous);
+        }
+        public boolean isTermination() { return true; }
+    }
+
+    private final ArrayList<LinkedBlockingQueue<Message>> buffers;
+    private final ExecutorService executor;
+    private final ArrayList<Callable<Throwable>> actions;
+    private final ArrayList<Future<Throwable>> futures;
+
+    public ParallelFork(Duct[] allNext) {
+        super(allNext);
+
+        this.executor = Executors.newFixedThreadPool(allNext.length);
+
+        /* Obvious choices for nThread in newFixedThreadPool:
+            * nThreads = allNext.length. Potential to create a lot of thread-thrashing on machines with few cores, but
+                        the OS scheduler should ensure any executable thread gets a chance to proceed (and possibly
+                        complete, enabling others down a Local*Gate to proceed)
+            * nThreads = #of CPU. Would work, possibly by chance as long as #of CPU is "big enough" (see below)
+            * nThreads=1 : "parallel" is parallel with respect to upstream. This could work sometimes, but will still
+                deadlock in the Fork-CoGroup-HashJoin scenario, as the other side of join could still be starved by
+                one side not completing.
+            * nThreads = max(# of pipes merged into a CoGroup or HashJoin downstream from here). This is the minimum
+                required to guarantee one side can't starve another. It COULD probably be queried from the flow graph,
+                factoring in for all potential combinations...
+
+            Therefore, the easy safe choice is to take allNext.length.
+        */
+
+        ArrayList<LinkedBlockingQueue<Message>> buffers = new ArrayList<LinkedBlockingQueue<Message>>(allNext.length);
+        ArrayList<Future<Throwable>> futures = new ArrayList<Future<Throwable>>(allNext.length);
+        ArrayList<Callable<Throwable>> actions = new ArrayList<Callable<Throwable>>(allNext.length);
+
+        final ParallelFork self = this;
+        for (int i = 0; i < allNext.length; ++i) {
+            final LinkedBlockingQueue<Message> queue = new LinkedBlockingQueue<Message>();
+            final Duct next = allNext[i];
+
+            buffers.add(queue);
+            Callable<Throwable> action = new Callable<Throwable>() {
+                @Override
+                public Throwable call() throws Exception {
+                    try {
+                        while (true) {
+                            Message message = queue.take();
+                            message.passOn(next);
+                            if (message.isTermination()) {
+                                return null;
+                            }
+                        }
+                    } catch (Throwable throwable) {
+                        return throwable;
+                    }
+                }
+            };
+
+            actions.add(action);
+        }
+        this.buffers = buffers;
+        this.actions = actions;
+        this.futures = futures;
+    }
+
+    @Override
+    public void initialize() {
+        super.initialize();
+    }
+
+    private void broadcastMessage(Message message) {
+        for (LinkedBlockingQueue<Message> queue: buffers) {
+            queue.offer(message);
+        }
+    }
+
+    private WeakReference<Duct> started = null;
+
+    @Override
+    public void start(Duct previous) {
+        LOG.debug("StartMessage {} BEGIN", previous);
+        synchronized (this) {
+            if (started != null) {
+                LOG.error("ParallelFork already started! former previous={}, new previous={}", started.get(), previous);
+                return;
+            }
+            if (completed != null) {
+                throw new IllegalStateException("cannot start an already completed ParallelFork");
+            }
+            started = new WeakReference<Duct>(previous);
+        }
+
+        try {
+            for (Callable<Throwable> action : actions) {
+                Future<Throwable> future = executor.submit(action);
+                futures.add(future);
+            }
+
+            CountDownLatch startLatch = new CountDownLatch(allNext.length);
+            broadcastMessage(new StartMessage(previous, startLatch));
+
+            startLatch.await(); // wait for all threads to have started
+        } catch (InterruptedException iex) {
+            throw new UndeclaredThrowableException(iex);
+        }
+    }
+
+    @Override
+    public void receive(Duct previous, TupleEntry incoming) {
+        broadcastMessage(new ReceiveMessage(previous, incoming ));
+            /* incoming is copied once for each downstream pipe, within the current thread. */
+    }
+
+    private WeakReference<Duct> completed = null; /* records origin duct */
+
+
+    @Override
+    public void complete(Duct previous) {
+        synchronized (this) {
+            if (completed != null) {
+                LOG.error("ParallelFork already complete! former previous={} new previous={}", completed.get(), previous);
+                return;
+            }
+            completed = new WeakReference<Duct>(previous);
+        }
+
+        broadcastMessage(new CompleteMessage(previous));
+        /* the CompleteMessage will cause the downstream threads to complete */
+
+        try {
+            for (Future<Throwable> future : futures) {
+                Throwable throwable;
+                try {
+                    throwable = future.get();
+                } catch (InterruptedException iex) {
+                    throwable = iex;
+                } catch (ExecutionException cex) {
+                    throwable = cex;
+                }
+
+                if (throwable != null) {
+                    throw new RuntimeException(throwable);
+                }
+            }
+        } finally {
+            executor.shutdown();
+        }
+    }
+}

--- a/cascading-local/src/main/java/cascading/flow/local/stream/graph/LocalStepStreamGraph.java
+++ b/cascading-local/src/main/java/cascading/flow/local/stream/graph/LocalStepStreamGraph.java
@@ -27,6 +27,7 @@ import cascading.flow.FlowNode;
 import cascading.flow.FlowProcess;
 import cascading.flow.local.LocalFlowProcess;
 import cascading.flow.local.LocalFlowStep;
+import cascading.flow.local.stream.duct.ParallelFork;
 import cascading.flow.local.stream.element.LocalGroupByGate;
 import cascading.flow.local.stream.element.SyncMergeStage;
 import cascading.flow.stream.duct.Duct;
@@ -75,7 +76,13 @@ public class LocalStepStreamGraph extends NodeStreamGraph
       }
     }
 
-  protected Gate createCoGroupGate( CoGroup element, IORole role )
+  @Override
+  protected Duct createFork(Duct[] allNext)
+    {
+    return new ParallelFork( allNext );
+    }
+
+  protected Gate createCoGroupGate(CoGroup element, IORole role )
     {
     return new MemoryCoGroupGate( flowProcess, element );
     }

--- a/cascading-platform/src/test/java/cascading/JoinFieldedPipesPlatformTest.java
+++ b/cascading-platform/src/test/java/cascading/JoinFieldedPipesPlatformTest.java
@@ -27,16 +27,22 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
 import cascading.flow.Flow;
 import cascading.flow.FlowDef;
 import cascading.flow.FlowStep;
+import cascading.flow.FlowProcess;
+
 import cascading.flow.planner.graph.ElementGraph;
 import cascading.operation.Aggregator;
+import cascading.operation.BaseOperation;
 import cascading.operation.Function;
+import cascading.operation.FunctionCall;
 import cascading.operation.Identity;
+
 import cascading.operation.aggregator.Count;
 import cascading.operation.aggregator.First;
 import cascading.operation.expression.ExpressionFunction;
@@ -50,6 +56,7 @@ import cascading.pipe.GroupBy;
 import cascading.pipe.HashJoin;
 import cascading.pipe.Merge;
 import cascading.pipe.Pipe;
+import cascading.pipe.assembly.Rename;
 import cascading.pipe.joiner.InnerJoin;
 import cascading.pipe.joiner.Joiner;
 import cascading.pipe.joiner.LeftJoin;
@@ -61,6 +68,8 @@ import cascading.tap.Tap;
 import cascading.tuple.Fields;
 import cascading.tuple.Hasher;
 import cascading.tuple.Tuple;
+import cascading.tuple.TupleEntry;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static data.InputData.*;
@@ -193,6 +202,164 @@ public class JoinFieldedPipesPlatformTest extends PlatformTestCase
     assertTrue( values.contains( new Tuple( "1\ta\t1\tA" ) ) );
     assertTrue( values.contains( new Tuple( "2\tb\t2\tB" ) ) );
     }
+
+    /**
+     * This test checks for a deadlock when the same input is forked, adapted on one edge, then hashjoined back together.
+     * @throws Exception
+       */
+    @Test
+    @Ignore /* this test fails under Tez, for now. The other "testForkThen.*Join.*" already validate the need for
+     ParallelFork on cascading-local -- cchepelov, 2016-01-12 */
+    public void testForkThenJoin() throws Exception
+    {
+      getPlatform().copyFromLocal( inputFileLower );
+      Tap sourceLower = getPlatform().getTextFile( new Fields( "offset", "line" ), inputFileLower );
+
+      Map sources = new HashMap();
+
+      sources.put( "lower", sourceLower );
+
+      Tap sink = getPlatform().getTextFile( new Fields( "line" ), getOutputPath( "join" ), SinkMode.REPLACE );
+
+      Function splitter = new RegexSplitter( new Fields( "num", "text" ), " " );
+
+      Pipe pipeLower = new Each( new Pipe( "lower" ), new Fields( "line" ), splitter );
+      Pipe pipeUpper = new Each( new Pipe("upper", pipeLower), new Fields( "text" ),
+              new ExpressionFunction( Fields.ARGS, "text.toUpperCase(java.util.Locale.ROOT)", String.class ),
+              Fields.REPLACE);
+
+      Pipe splice = new HashJoin( pipeLower, new Fields( "num" ), pipeUpper, new Fields( "num" ), Fields.size( 4 ) );
+
+      Map<Object, Object> properties = getProperties();
+
+      Flow flow = getPlatform().getFlowConnector( properties ).connect( sources, sink, splice );
+
+      flow.complete();
+
+      validateLength( flow, 5 );
+
+      List<Tuple> values = getSinkAsList( flow );
+
+      assertTrue( values.contains( new Tuple( "1\ta\t1\tA" ) ) );
+      assertTrue( values.contains( new Tuple( "2\tb\t2\tB" ) ) );
+    }
+
+    /**
+     * This test checks for a deadlock when the same input is forked, adapted on one edge, then hashjoined back together.
+     * @throws Exception
+     */
+    @Test
+    public void testForkCoGroupThenHashJoin() throws Exception
+    {
+      getPlatform().copyFromLocal( inputFileLower );
+      Tap sourceLower = getPlatform().getTextFile( new Fields( "offset", "line" ), inputFileLower );
+      Tap sourceUpper = getPlatform().getTextFile( new Fields( "offset", "line" ), inputFileUpper );
+
+      Map sources = new HashMap();
+
+      sources.put( "sourceLower", sourceLower );
+      sources.put( "sourceUpper", sourceUpper );
+
+      Tap sink = getPlatform().getTextFile( new Fields( "line" ), getOutputPath( "join" ), SinkMode.REPLACE );
+
+      Function splitter = new RegexSplitter( new Fields( "num", "text" ), " " );
+
+      Pipe leftPipeLower = new Each( new Pipe( "sourceLower" ), new Fields( "line" ), splitter );
+      Pipe rightPipeUpper = new Each( new Pipe( "sourceUpper" ), new Fields( "line" ), splitter );
+
+      Pipe leftPipeUpper = new Each( new Pipe( "leftUpper", leftPipeLower), new Fields( "text" ),
+              new ExpressionFunction( Fields.ARGS, "text.toUpperCase(java.util.Locale.ROOT)", String.class ),
+              Fields.REPLACE);
+      Pipe rightPipeLower = new Each( new Pipe( "rightLower", rightPipeUpper), new Fields( "text" ),
+              new ExpressionFunction( Fields.ARGS, "text.toLowerCase(java.util.Locale.ROOT)", String.class ),
+              Fields.REPLACE);
+
+      leftPipeUpper = new GroupBy(leftPipeUpper, new Fields("num"));
+      rightPipeLower = new GroupBy(rightPipeLower, new Fields("num"));
+
+      Pipe middleSplice = new CoGroup("middleCoGroup", leftPipeUpper, new Fields( "num" ), rightPipeLower, new Fields( "num" ), new Fields( "numM1", "charM1", "numM2", "charM2" )  );
+
+      Pipe leftSplice = new HashJoin(leftPipeLower, new Fields("num"), middleSplice, new Fields("numM1"));
+
+      Map<Object, Object> properties = getProperties();
+
+      Flow flow = getPlatform().getFlowConnector( properties ).connect( sources, sink, leftSplice);
+
+      flow.complete();
+
+      validateLength( flow, 5 );
+
+      List<Tuple> values = getSinkAsList( flow );
+      // that the flow completes at all is already success.
+      assertTrue( values.contains( new Tuple( "1\ta\t1\tA\t1\ta" ) ) );
+      assertTrue( values.contains( new Tuple( "2\tb\t2\tB\t2\tb" ) ) );
+    }
+
+    /**
+     * This test checks for a deadlock when the same input is forked, adapted on one edge, cogroup with something,
+     * then hashjoined back together.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testForkCoGroupThenHashJoinCoGroupAgain() throws Exception
+    {
+      getPlatform().copyFromLocal( inputFileLower );
+      getPlatform().copyFromLocal( inputFileUpper );
+
+      Tap sourceLower = getPlatform().getTextFile( new Fields( "offset", "line" ), inputFileLower );
+      Tap sourceUpper = getPlatform().getTextFile( new Fields( "offset", "line" ), inputFileUpper );
+
+      Map sources = new HashMap();
+
+      sources.put( "sourceLower", sourceLower );
+      sources.put( "sourceUpper", sourceUpper );
+
+      Tap sink = getPlatform().getTextFile( new Fields( "line" ), getOutputPath( "join" ), SinkMode.REPLACE );
+
+      Function splitter = new RegexSplitter( new Fields( "num", "text" ), " " );
+
+      Pipe leftPipeLower = new Each( new Pipe( "sourceLower" ), new Fields( "line" ), splitter );
+      Pipe rightPipeUpper = new Each( new Pipe( "sourceUpper" ), new Fields( "line" ), splitter );
+
+      Pipe leftPipeUpper = new Each( new Pipe( "leftUpper", leftPipeLower), new Fields( "text" ),
+              new ExpressionFunction( Fields.ARGS, "text.toUpperCase(java.util.Locale.ROOT)", String.class ),
+              Fields.REPLACE);
+      Pipe rightPipeLower = new Each( new Pipe( "rightLower", rightPipeUpper), new Fields( "text" ),
+              new ExpressionFunction( Fields.ARGS, "text.toLowerCase(java.util.Locale.ROOT)", String.class ),
+              Fields.REPLACE);
+
+      leftPipeUpper = new GroupBy(leftPipeUpper, new Fields("num"));
+      rightPipeLower = new GroupBy(rightPipeLower, new Fields("num"));
+
+      Pipe middleSplice = new CoGroup("middleCoGroup", leftPipeUpper, new Fields( "num" ), rightPipeLower, new Fields( "num" ), new Fields( "numM1", "charM1", "numM2", "charM2" )  );
+
+      Pipe leftSplice = new HashJoin(leftPipeLower, new Fields("num"), middleSplice, new Fields("numM1"));
+      Pipe rightSplice = new HashJoin(rightPipeUpper, new Fields("num"), middleSplice, new Fields("numM2"));
+
+      leftSplice = new Rename(leftSplice, new Fields("num", "text", "numM1", "charM1", "numM2", "charM2"), new Fields("numL1", "charL1", "numM1L", "charM1L", "numM2L", "charM2L"));
+      rightSplice = new Rename(rightSplice, new Fields("num", "text", "numM1", "charM1", "numM2", "charM2"), new Fields("numR1", "charR1", "numM1R", "charM1R", "numM2R", "charM2R"));
+
+      leftSplice = new GroupBy(leftSplice, new Fields("numM1L"));
+      rightSplice = new GroupBy(rightSplice, new Fields("numM2R"));
+
+      Pipe splice = new CoGroup( "cogrouping", leftSplice, new Fields( "numM1L" ), rightSplice, new Fields( "numM2R" ) );
+
+      Map<Object, Object> properties = getProperties();
+
+      Flow flow = getPlatform().getFlowConnector( properties ).connect( sources, sink, splice);
+
+      flow.complete();
+
+      validateLength( flow, 5 );
+
+      List<Tuple> values = getSinkAsList( flow );
+
+      // getting this far is a success already (past old deadlocks)
+      assertTrue( values.contains( new Tuple( "1\ta\t1\tA\t1\ta\t1\tA\t1\tA\t1\ta" ) ) );
+      assertTrue( values.contains( new Tuple( "2\tb\t2\tB\t2\tb\t2\tB\t2\tB\t2\tb" ) ) );
+    }
+
 
   @Test
   public void testJoinWithUnknowns() throws Exception


### PR DESCRIPTION
…(e.g. Scalding's SkewedJoin)

```
(fix expected output)

cascading-local: use ParallelFork to avoid deadlocks in Fork-HashJoin scenarios

java7 compatibility

(to be fair, workStealingThreadPool worked by chance, as there are more cores on my machine than the maximum amount of inbound pipes in the joins present downstream from a fork in the test suite)

(forgotten test input file needs to go to the platform)

Disabling the cascading.JoinFieldedPipesPlatformTest.testForkThenJoin test, which fails under Tez (for an unrelated cause)

remove spurious janino import

removed custom functions, replaced by ExpressionFunctions
```

Author: Cyrille Chépélov (TP12) cch@transparencyrights.com
Date:   Thu Jan 7 10:44:04 2016 +0100
