### PR TITLE
Hadoop "new API" detection using type info

### DIFF
--- a/cascading-hadoop/src/main/shared-io/cascading/flow/hadoop/util/HadoopUtil.java
+++ b/cascading-hadoop/src/main/shared-io/cascading/flow/hadoop/util/HadoopUtil.java
@@ -800,13 +800,36 @@ public class HadoopUtil
     conf.set( "tez.runtime.optimize.local.fetch", "true" );
     }
 
+  private static boolean interfaceAssignableFromClassName(Class<?> xface, String className)
+    {
+      if ((className == null) || (xface == null))
+        return false;
+
+      try {
+        Class<?> klass = Class.forName(className);
+        if (klass == null)
+          return false;
+
+        if (!xface.isAssignableFrom(klass))
+          return false;
+
+        return true;
+      } catch (ClassNotFoundException cnfe) {
+        return false; // let downstream figure it out
+      }
+    }
+
+
   public static boolean setNewApi( Configuration conf, String className )
     {
     if( className == null ) // silently return and let the error be caught downstream
       return false;
 
-    boolean isStable = className.startsWith( "org.apache.hadoop.mapred." );
-    boolean isNew = className.startsWith( "org.apache.hadoop.mapreduce." );
+    boolean isStable = className.startsWith( "org.apache.hadoop.mapred." )
+            || interfaceAssignableFromClassName(org.apache.hadoop.mapred.InputFormat.class, className);
+
+    boolean isNew = className.startsWith( "org.apache.hadoop.mapreduce." )
+            || interfaceAssignableFromClassName(org.apache.hadoop.mapreduce.InputFormat.class, className);
 
     if( isStable )
       conf.setBoolean( "mapred.mapper.new-api", false );


### PR DESCRIPTION
Currently, `HadoopUtil#setNewApi()` will automatically deduce the API flavour using the namespace of the InputFormat, comparing the namespace name with "org.apache.hadoop.mapred." or "o.a.h.mapreduce.".

In case a third-party InputFormat is supplied (such as in the case of the Scalding test suite, which uses some MemoryInputFormats from Maple), this detection fails and the planner sometimes refuses to deal with the Flow. _(An easy workaround is to set mapred.mapper.new-api)_

This patch improves the detection logic using Reflection to inspect which interface ("stable" or "new") the selected InputFormat is using, falling back to the old logic if the class is unavailable at planning stage.
