### PR TITLE
Change `getNext` to use a loop instead of recursion

### DIFF
--- a/cascading-core/src/main/java/cascading/tuple/TupleEntrySchemeIterator.java
+++ b/cascading-core/src/main/java/cascading/tuple/TupleEntrySchemeIterator.java
@@ -165,11 +165,12 @@ public class TupleEntrySchemeIterator<Config, Input> extends TupleEntryIterator
     Tuples.asModifiable( sourceCall.getIncomingEntry().getTuple() );
     hasWaiting = scheme.source( flowProcess, sourceCall );
 
-    if( !hasWaiting && inputIterator.hasNext() )
+    while ( !hasWaiting && inputIterator.hasNext() )
       {
       sourceCall.setInput( wrapInput( inputIterator.next() ) );
 
-      return getNext();
+      Tuples.asModifiable( sourceCall.getIncomingEntry().getTuple() );
+      hasWaiting = scheme.source( flowProcess, sourceCall );
       }
 
     return getTupleEntry();


### PR DESCRIPTION
The motivation behind this change is to improve the legibility of stack traces
involving `TupleEntrySchemeIterator.java#getNext`

While testing this change the test suite transiently failed once with the following error:

```

cascading.cascade.ParallelCascadePlatformTest > testCascadeRaceCondition FAILED
    cascading.cascade.CascadeException at ParallelCascadePlatformTest.java:153
        Caused by: java.lang.IllegalStateException

556 tests completed, 1 failed
:cascading-local:platformTest FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':cascading-local:platformTest'.
> There were failing tests. See the report at: file:///Users/ggonzalez/proj/cascading/cascading-local/build/reports/tests/index.html

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 2 mins 11.081 secs
```

However, I cannot reproduce the test failure when I rerun the test, so I'm not sure if this is a race condition that my change introduced or if I just got unlucky and triggered a pre-existing race condition.  I've tried running this specific test 10 more times in an unsuccessful attempt to reproduce the error (both before and after the change).

I figured I should just open the pull request anyway and let you look at the change since you may have more context about whether or not this change might relate to this race condition.
