### PR TITLE
Add failing test for union of steps

### DIFF
--- a/cascading-platform/src/test/java/cascading/MergePipesPlatformTest.java
+++ b/cascading-platform/src/test/java/cascading/MergePipesPlatformTest.java
@@ -31,6 +31,7 @@ import cascading.operation.Identity;
 import cascading.operation.aggregator.First;
 import cascading.operation.regex.RegexFilter;
 import cascading.operation.regex.RegexSplitter;
+import cascading.pipe.Checkpoint;
 import cascading.pipe.CoGroup;
 import cascading.pipe.Each;
 import cascading.pipe.Every;
@@ -389,6 +390,45 @@ public class MergePipesPlatformTest extends PlatformTestCase
       // ignore
       }
     }
+
+  @Test
+  public void testMergeAndWriteToTwoSinks() throws Exception {
+    getPlatform().copyFromLocal( inputFileLower );
+    getPlatform().copyFromLocal( inputFileUpper );
+
+    Tap sourceLower = getPlatform().getTextFile( inputFileLower );
+    Tap sourceUpper = getPlatform().getTextFile( inputFileUpper );
+
+    Map sources = new HashMap();
+
+    sources.put( "lower", sourceLower );
+    sources.put( "upper", sourceUpper );
+
+    Tap sink1 = getPlatform().getTextFile( getOutputPath( "sink1" ), SinkMode.REPLACE );
+    Tap sink2 = getPlatform().getTextFile( getOutputPath( "sink2" ), SinkMode.REPLACE );
+
+    Map sinks = new HashMap();
+
+    sinks.put( "sink1", sink1 );
+    sinks.put( "sink2", sink2 );
+
+    Pipe pipeLower = new Each( new Pipe( "lower" ), new Fields( "line" ), new Identity( new Fields( "line" ) ) );
+    Pipe pipeUpper = new Each( new Pipe( "upper" ), new Fields( "line" ), new Identity( new Fields( "line" ) ) );
+
+    Pipe splice = new Merge( "merge", pipeLower, pipeUpper );
+
+    splice = new GroupBy( splice, new Fields( "line" ) );
+
+    Pipe tail1 = new Each( new Pipe( "sink1", splice ), new Fields( "line" ), new Identity( new Fields( "line" ) ) );
+    Pipe tail2 = new Each( new Pipe( "sink2", splice ), new Fields( "line" ), new Identity( new Fields( "line" ) ) );
+
+    tail2 = new Checkpoint( tail2 ); // test passes if this Checkpoint is removed
+
+    tail2 = new Each( tail2, new Fields( "line" ), new Identity( new Fields( "line" ) ) );
+
+    Flow flow = getPlatform().getFlowConnector().connect( sources, sinks, tail1, tail2 );
+    flow.complete();
+  }
 
   @Test
   public void testMergeIntoHashJoinStreamed() throws Exception


### PR DESCRIPTION
This fails with the following error:

```
cascading.flow.planner.PlannerException: union of steps have 1 fewer elements than parent assembly: MapReduceHadoopRuleRegistry, missing: [Each(sink2)[Identity[decl:'line']]]
    at cascading.flow.planner.FlowPlanner.verifyResultInternal(FlowPlanner.java:623)
    at cascading.flow.planner.FlowPlanner.verifyResult(FlowPlanner.java:562)
    at cascading.flow.planner.rule.RuleSetExec.execPlannerFor(RuleSetExec.java:163)
    at cascading.flow.planner.rule.RuleSetExec$3.call(RuleSetExec.java:336)
    at cascading.flow.planner.rule.RuleSetExec$3.call(RuleSetExec.java:328)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
```

Corresponding Scalding code for this is something like:

``` scala
  val input1 = TypedPipe.from(joinInput1)
  val input2 = TypedPipe.from(joinInput2)

  val merged = (input1 ++ input2).asKeys.group.size

  merged
    .forceToDisk // works if this forceToDisk is removed
    .write(output)

  merged
    .write(output2)
```

Or in the fields api:

``` scala
  val input1 = joinInput1.read.mapTo(0 -> 'id) { v: Int => v }
  val input2 = joinInput2.read.mapTo(0 -> 'id) { v: Int => v }

  val merged = (input1 ++ input2).groupBy('id) { _.size('count) }

  merged
    .project('id, 'count)
    .forceToDisk // works if this forceToDisk is removed
    .write(output)

  merged
    .write(output2)
```

Relates to https://github.com/twitter/scalding/issues/1465
