### PR TITLE
Failing Cascading3 cogroup test

### DIFF
--- a/cascading-platform/src/test/java/cascading/FailingSelfJoinTest.java
+++ b/cascading-platform/src/test/java/cascading/FailingSelfJoinTest.java
@@ -1,0 +1,53 @@
+package cascading;
+
+import cascading.flow.Flow;
+import cascading.operation.Identity;
+import cascading.operation.aggregator.Count;
+import cascading.pipe.*;
+import cascading.tap.SinkMode;
+import cascading.tap.Tap;
+import cascading.tuple.Fields;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static data.InputData.inputFileLower;
+import static data.InputData.inputFileUpper;
+
+public class FailingSelfJoinTest extends PlatformTestCase {
+
+    public FailingSelfJoinTest() {
+        super(true); // leave cluster testing enabled
+    }
+
+    @Test
+    public void testFailingJob() throws Exception {
+        getPlatform().copyFromLocal(inputFileLower);
+        getPlatform().copyFromLocal(inputFileUpper);
+
+        Map sources = new HashMap();
+        sources.put("lower", getPlatform().getTextFile(inputFileLower));
+        sources.put("upper", getPlatform().getTextFile(inputFileUpper));
+
+        Tap sink = getPlatform().getTextFile(getOutputPath("sink"), SinkMode.REPLACE);
+
+        Pipe pipeLower = new Each(new Pipe("lower"), new Fields("line"), new Identity(new Fields("lineLower")));
+        Pipe pipeUpper = new Each(new Pipe("upper"), new Fields("line"), new Identity(new Fields("line")));
+
+        Pipe upperGroupBy = new GroupBy(new Pipe[]{pipeUpper}, new Fields("line"));
+        Pipe grpByEvery = new Every(upperGroupBy, new Count(), new Fields("line"));
+
+        Pipe grpByEveryE1 = new Each(grpByEvery, new Fields("line"), new Identity(new Fields("line")));
+        Pipe grpByEveryE2 = new Each(grpByEvery, new Fields("line"), new Identity(new Fields("linegrpE2")));
+
+        Pipe cogroup = new CoGroup("cogroup", pipeLower, new Fields("lineLower"), grpByEveryE1, new Fields("line"));
+        Each cogroupEach = new Each(cogroup, new Fields("line"), new Identity(new Fields("line")));
+
+        Pipe cogroupNested = new CoGroup(cogroupEach, new Fields("line"), grpByEveryE2, new Fields("linegrpE2"));
+        Pipe cogrpNestedEach = new Each(cogroupNested, new Fields("line"), new Identity(new Fields("line")));
+
+        Flow flow = getPlatform().getFlowConnector().connect(sources, sink, cogrpNestedEach);
+        flow.complete();
+    }
+}


### PR DESCRIPTION
This test ends up failing with a planner error: cascading.flow.planner.PlannerException: union of steps have 1 fewer elements than parent assembly: MapReduceHadoopRuleRegistry, missing: [Each(upper)[Identity[decl:'line']]]

Seems like the [TapGroupTapStepPartitioner](https://github.com/cwensel/cascading/blob/wip-3.2/cascading-hadoop/src/main/shared/cascading/flow/hadoop/planner/rule/partitioner/TapGroupTapStepPartitioner.java) rule is where are losing this Each operation. Haven't been able to pinpoint the reason / bug yet though. 

Maps to this failing Scalding job (with a few simplifications):

```
class TestJob(args: Args) extends Job(args) {
  val previousTP: TypedPipe[(String, String, Seq[String])] = TypedPipe.from(previousData)
  val deletedTP: TypedPipe[String] = TypedPipe.from(deletedUsers)

  val mergedEdges =
    previousTP
    .groupBy(x => (x._1, x._2))
    .mapValueStream(x => x) // in the actual job this is a semi group 
    .values
    //.forceToDisk here helps avoid planner error 

  val edgesToDel =
    mergedEdges
      .flatMap { edgeTuple =>
        edgeTuple._3.map { userId =>
          (userId, edgeTuple)
        }
      }
      .join(deletedTP.asKeys)
      .toTypedPipe
      .map { case (userId, ((idA, idB, userIDSeq), meh)) => (idA, idB) }
    //.forceToDisk here helps avoid planner error

    mergedEdges
      .groupBy(x => (x._1, x._2))
      .leftJoin(edgesToDel.asKeys) 
      .toTypedPipe
      .write(output)
}
```
