### PR TITLE
Fix assemble failure after gradle update in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,7 +166,7 @@ subprojects {
 
     copy {
       into "${distDir}/lib/${archivesBaseName}"
-      from( configurations.compile.resolvedConfiguration.firstLevelModuleDependencies.findAll {dep ->
+      from( configurations.compileClasspath.resolvedConfiguration.firstLevelModuleDependencies.findAll {dep ->
         !dep.name.contains( 'cascading' )
       }.collect {dep ->
         dep.moduleArtifacts.collect {it.file}


### PR DESCRIPTION
```java
Could not get unknown property 'compile' for configuration container of type org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer.
```