### PR TITLE
Add CI for tests on PR

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,4 +24,4 @@ jobs:
 
       - name: Run Full Tests
         run: |
-          ./gradlew clean check -i
+          ./gradlew clean check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,30 +12,6 @@ on:
 jobs:
   run-base-tests:
     runs-on: ubuntu-latest
-    strategy:
-      # it's helpful to see exactly which test modules passed/failed
-      # this finishes all matrix nodes even if one fails along the way
-      fail-fast: false
-
-      # all combinations that we will run in parallel to increase throughput
-      matrix:
-        include:
-          - BUILD: "cascading-core"
-          - BUILD: "cascading-expression"
-          - BUILD: "cascading-hadoop3-common"
-          - BUILD: "cascading-hadoop3-io"
-          - BUILD: "cascading-hadoop3-mr1"
-          - BUILD: "cascading-hadoop3-tez"
-          - BUILD: "cascading-hadoop3-tez-stats"
-          - BUILD: "cascading-local"
-          - BUILD: "cascading-local-hadoop3-io"
-          - BUILD: "cascading-local-kafka"
-          - BUILD: "cascading-local-neo4j"
-          - BUILD: "cascading-local-s3"
-          - BUILD: "cascading-local-splunk"
-          - BUILD: "cascading-nested"
-          - BUILD: "cascading-nested-json"
-          - BUILD: "cascading-platform"
 
     steps:
       - name: Checkout Repo
@@ -46,11 +22,6 @@ jobs:
           distribution: 'adopt-openj9'
           java-version: 8
 
-
-      - name: "Run Full Module Build"
-        env:
-          BUILD: ${{ matrix.BUILD }}
-
+      - name: Run Full Tests
         run: |
-          cd $BUILD
-          ../gradlew build
+          ./gradlew clean check -i

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,56 @@
+name: CI
+
+# run on all branches
+on:
+  pull_request:
+    branches:
+      - '**'
+  push:
+    branches:
+      - '**'
+
+jobs:
+  run-base-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      # it's helpful to see exactly which test modules passed/failed
+      # this finishes all matrix nodes even if one fails along the way
+      fail-fast: false
+
+      # all combinations that we will run in parallel to increase throughput
+      matrix:
+        include:
+          - BUILD: "cascading-core"
+          - BUILD: "cascading-expression"
+          - BUILD: "cascading-hadoop3-common"
+          - BUILD: "cascading-hadoop3-io"
+          - BUILD: "cascading-hadoop3-mr1"
+          - BUILD: "cascading-hadoop3-tez"
+          - BUILD: "cascading-hadoop3-tez-stats"
+          - BUILD: "cascading-local"
+          - BUILD: "cascading-local-hadoop3-io"
+          - BUILD: "cascading-local-kafka"
+          - BUILD: "cascading-local-neo4j"
+          - BUILD: "cascading-local-s3"
+          - BUILD: "cascading-local-splunk"
+          - BUILD: "cascading-nested"
+          - BUILD: "cascading-nested-json"
+          - BUILD: "cascading-platform"
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt-openj9'
+          java-version: 8
+
+
+      - name: "Run Full Module Build"
+        env:
+          BUILD: ${{ matrix.BUILD }}
+
+        run: |
+          cd $BUILD
+          ../gradlew build


### PR DESCRIPTION
for each module trigger `../gradlew build` to run test suite. Run modules in parallel. 

For future optimization, it makes sense to exclude `test` for all sub-dependent projects on the require chain. Not sure how to easily accomplish this but can be done with some modifications to the gradle file. 

This will speed up everything significantly since downstream dependencies won't have their tests run multiple times.

For now I think this is a good start though. 

![Screen Shot 2022-03-02 at 12 10 29 PM](https://user-images.githubusercontent.com/52898838/156441659-50624f9a-814f-42c7-89da-936174b4eeaa.png)
 